### PR TITLE
Fix "too many rerenders" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bug that caused the component to break when a huge value was input in the quantity selector.
+
 ## [0.2.0] - 2019-08-15
 
 ### Changed

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -4,6 +4,9 @@ import { IconDelete } from 'vtex.styleguide'
 import FormattedPrice from './FormattedPrice'
 import Selector from './QuantitySelector'
 
+const MAX_ITEM_QUANTITY = 99999
+const MAX_ITEM_QUANTITY_LENGTH = 5
+
 interface Props {
   currency: string
   item: Item
@@ -69,10 +72,20 @@ const ListItem: FunctionComponent<Props> = ({
       {/* Quantity Selector */}
       <div className="flex-auto-m mt6-m">
         <div className="dn-m" style={{ width: '70px' }}>
-          <Selector value={item.quantity} onChange={onQuantityChange} />
+          <Selector
+            value={item.quantity}
+            maxValue={MAX_ITEM_QUANTITY}
+            maxLength={MAX_ITEM_QUANTITY_LENGTH}
+            onChange={onQuantityChange}
+          />
         </div>
         <div className="dn db-m" style={{ width: '90px' }}>
-          <Selector value={item.quantity} onChange={onQuantityChange} />
+          <Selector
+            value={item.quantity}
+            maxValue={MAX_ITEM_QUANTITY}
+            maxLength={MAX_ITEM_QUANTITY_LENGTH}
+            onChange={onQuantityChange}
+          />
         </div>
 
         {item.quantity > 1 && (

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -5,7 +5,6 @@ import FormattedPrice from './FormattedPrice'
 import Selector from './QuantitySelector'
 
 const MAX_ITEM_QUANTITY = 99999
-const MAX_ITEM_QUANTITY_LENGTH = 5
 
 interface Props {
   currency: string
@@ -75,7 +74,6 @@ const ListItem: FunctionComponent<Props> = ({
           <Selector
             value={item.quantity}
             maxValue={MAX_ITEM_QUANTITY}
-            maxLength={MAX_ITEM_QUANTITY_LENGTH}
             onChange={onQuantityChange}
           />
         </div>
@@ -83,7 +81,6 @@ const ListItem: FunctionComponent<Props> = ({
           <Selector
             value={item.quantity}
             maxValue={MAX_ITEM_QUANTITY}
-            maxLength={MAX_ITEM_QUANTITY_LENGTH}
             onChange={onQuantityChange}
           />
         </div>

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -9,38 +9,45 @@ enum SelectorType {
 
 interface Props {
   value: number
+  maxValue: number
+  maxLength: number
   onChange: (value: number) => void
 }
 
-const validateValue = (value: string) => {
+const normalizeValue = (value: number, maxValue: number) => value > maxValue ? maxValue : value
+
+const validateValue = (value: string, maxValue: number) => {
   const parsedValue = parseInt(value, 10)
 
   if (isNaN(parsedValue) || parsedValue === 0) {
     return 1
   }
 
-  return parseInt(value, 10)
+  return normalizeValue(parseInt(value, 10), maxValue)
 }
 
-const validateDisplayValue = (value: string) => {
+const validateDisplayValue = (value: string, maxValue: number) => {
   const parsedValue = parseInt(value, 10)
 
   if (isNaN(parsedValue) || parsedValue < 1) {
     return ''
   }
 
-  return `${parsedValue}`
+  return `${normalizeValue(parsedValue, maxValue)}`
 }
 
-const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
+const QuantitySelector: FunctionComponent<Props> = ({ value, maxValue, maxLength, onChange }) => {
   const [curSelector, setSelector] = useState(
     value < 10 ? SelectorType.Dropdown : SelectorType.Input
   )
-  const [curDisplayValue, setDisplayValue] = useState(`${value}`)
+
+  const normalizedValue = normalizeValue(value, maxValue)
+
+  const [curDisplayValue, setDisplayValue] = useState(`${normalizedValue}`)
 
   const handleChange = (value: string) => {
-    const validatedValue = validateValue(value)
-    const displayValue = validateDisplayValue(value)
+    const validatedValue = validateValue(value, maxValue)
+    const displayValue = validateDisplayValue(value, maxValue)
 
     if (validatedValue >= 10 && curSelector === SelectorType.Dropdown) {
       setSelector(SelectorType.Input)
@@ -56,11 +63,11 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
     }
   }
 
-  if (value !== validateValue(curDisplayValue)) {
-    if (value >= 10) {
+  if (normalizedValue !== validateValue(curDisplayValue, maxValue)) {
+    if (normalizedValue >= 10) {
       setSelector(SelectorType.Input)
     }
-    setDisplayValue(validateDisplayValue(`${value}`))
+    setDisplayValue(validateDisplayValue(`${normalizedValue}`, maxValue))
   }
 
   if (curSelector === SelectorType.Dropdown) {
@@ -75,7 +82,7 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
           <Dropdown
             options={dropdownOptions}
             size="small"
-            value={value}
+            value={normalizedValue}
             onChange={(event: any) => handleChange(event.target.value)}
             placeholder=""
           />
@@ -83,7 +90,7 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
         <div className="dn db-l">
           <Dropdown
             options={dropdownOptions}
-            value={value}
+            value={normalizedValue}
             onChange={(event: any) => handleChange(event.target.value)}
             placeholder=""
           />
@@ -97,6 +104,7 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
           <Input
             size="small"
             value={curDisplayValue}
+            maxLength={maxLength}
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""
@@ -105,6 +113,7 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, onChange }) => {
         <div className="dn db-l">
           <Input
             value={curDisplayValue}
+            maxLength={maxLength}
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -14,7 +14,8 @@ interface Props {
   onChange: (value: number) => void
 }
 
-const normalizeValue = (value: number, maxValue: number) => value > maxValue ? maxValue : value
+const normalizeValue = (value: number, maxValue: number) =>
+  value > maxValue ? maxValue : value
 
 const validateValue = (value: string, maxValue: number) => {
   const parsedValue = parseInt(value, 10)
@@ -36,7 +37,25 @@ const validateDisplayValue = (value: string, maxValue: number) => {
   return `${normalizeValue(parsedValue, maxValue)}`
 }
 
-const QuantitySelector: FunctionComponent<Props> = ({ value, maxValue, maxLength, onChange }) => {
+const getDropdownOptions = (maxValue: number) => {
+  const limit = Math.min(9, maxValue)
+  const options = [
+    ...range(1, limit + 1).map(idx => ({ value: idx, label: `${idx}` })),
+  ]
+
+  if (maxValue >= 10) {
+    options.push({ value: 10, label: '10+' })
+  }
+
+  return options
+}
+
+const QuantitySelector: FunctionComponent<Props> = ({
+  value,
+  maxValue,
+  maxLength,
+  onChange,
+}) => {
   const [curSelector, setSelector] = useState(
     value < 10 ? SelectorType.Dropdown : SelectorType.Input
   )
@@ -71,10 +90,7 @@ const QuantitySelector: FunctionComponent<Props> = ({ value, maxValue, maxLength
   }
 
   if (curSelector === SelectorType.Dropdown) {
-    const dropdownOptions = [
-      ...range(1, 10).map(idx => ({ value: idx, label: idx })),
-      { value: 10, label: '10+' },
-    ]
+    const dropdownOptions = getDropdownOptions(maxValue)
 
     return (
       <div>

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -2,6 +2,8 @@ import { range } from 'ramda'
 import React, { FunctionComponent, useState } from 'react'
 import { Dropdown, Input } from 'vtex.styleguide'
 
+const MAX_INPUT_LENGTH = 5
+
 enum SelectorType {
   Dropdown,
   Input,
@@ -10,7 +12,6 @@ enum SelectorType {
 interface Props {
   value: number
   maxValue: number
-  maxLength: number
   onChange: (value: number) => void
 }
 
@@ -53,7 +54,6 @@ const getDropdownOptions = (maxValue: number) => {
 const QuantitySelector: FunctionComponent<Props> = ({
   value,
   maxValue,
-  maxLength,
   onChange,
 }) => {
   const [curSelector, setSelector] = useState(
@@ -120,7 +120,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
           <Input
             size="small"
             value={curDisplayValue}
-            maxLength={maxLength}
+            maxLength={MAX_INPUT_LENGTH}
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""
@@ -129,7 +129,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
         <div className="dn db-l">
           <Input
             value={curDisplayValue}
-            maxLength={maxLength}
+            maxLength={MAX_INPUT_LENGTH}
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""


### PR DESCRIPTION
#### What problem is this solving?

If one changes the quantity of some item in the cart to a value that is too large (around 22 digits), the component breaks with `Invariant Violation: Too many re-renders. React limits the number of renders to prevent an infinite loop.`. 
This happens because at some point Javascript starts representing the number in scientific notation (e.g. `2.123456e+20` instead of `212345600000000000000`). When that number is parsed using `parseInt`, it returns a value that is different from the actual one. This difference caused an infinite render loop in the `QuantitySelector` component because once that state is reached, the condition in line 59 always evaluates to true.
This was fixed by adding `maxValue` prop to `QuantitySelector` and setting a length limit to the `Input` component to prevent the user from inputting pathologic values.

#### How should this be manually tested?

[Broken workspace](https://cart--vtexgame1.myvtex.com)
[Fixed workspace](https://cart2--vtexgame1.myvtex.com)

Add some items to the cart, then visit `/cart` and test the quantity selector.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
