### PR TITLE
Remove title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed "Cart" title from component.
+
 ## [0.3.1] - 2019-08-20
 
-- Changed UI details to make layout work well and to improve some components' behavior
+### Changed
+
+- Changed UI details to make layout work well and to improve some components' behavior.
 
 ## [0.3.0] - 2019-08-19
 

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -14,13 +14,6 @@ const ProductList: FunctionComponent<Props> = ({
   onRemove,
 }) => (
   <div>
-    <h3 className="mh5 mh6-m">
-      <span className="t-heading-3 c-on-base t-heading-2-l">Cart</span>
-      <span className="t-heading-5 c-muted-1 t-heading-4-l">
-        &nbsp;({items.length} items)
-      </span>
-    </h3>
-
     {items.map((item: any, index: number) => (
       <ListItem
         key={index}


### PR DESCRIPTION
#### What problem is this solving?

This removes the "Cart" title from the `product-list` component. We're moving it to the `cart` component, which makes more sense.

#### How should this be manually tested?

[Titleless cart](https://productlisttitleless--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/18577/mover-texto-cart-x-items-do-product-list-para-o-cart)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
