### PR TITLE
Internationalize component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Price per unit text is now translated.
+
 ## [0.4.0] - 2019-08-26
 
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "description": "Product List",
   "defaultLocale": "pt-BR",
   "builders": {
+    "messages": "1.x",
     "store": "0.x",
     "react": "3.x"
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,4 @@
+{
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "per {measurementUnit}."
+}

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,0 +1,4 @@
+{
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
+}

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,0 +1,4 @@
+{
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
+}

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
 import { IconDelete } from 'vtex.styleguide'
 import { FormattedCurrency } from 'vtex.format-currency'
 
@@ -83,13 +84,24 @@ const ListItem: FunctionComponent<Props> = ({
 
         {item.quantity > 1 && (
           <div className="mt3 t-mini c-muted-1 tc-m lh-title">
-            <div className="dib">
-              <FormattedCurrency value={item.sellingPrice / 100} />
-            </div>
-            &nbsp;
-            <div className="dib">
-              per {item.measurementUnit}.
-            </div>
+            <FormattedMessage
+              id="store/product-list.pricePerUnit"
+              values={{
+                price: (
+                  <div className="dib">
+                    <FormattedCurrency value={item.sellingPrice / 100} />
+                  </div>
+                ),
+                perMeasurementUnit: (
+                  <div className="dib">
+                    <FormattedMessage
+                      id="store/product-list.pricePerUnit.measurementUnit"
+                      values={{ measurementUnit: item.measurementUnit }}
+                    />
+                  </div>
+                ),
+              }}
+            />
           </div>
         )}
       </div>

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -107,11 +107,15 @@ const ListItem: FunctionComponent<Props> = ({
       </div>
 
       {/* Price */}
-      <div className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}>
+      <div
+        className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}
+      >
         <div className="flex-auto">
           {item.listPrice !== item.price && (
             <div className="c-muted-1 strike t-mini mb2">
-              <FormattedCurrency value={(item.listPrice * item.quantity) / 100} />
+              <FormattedCurrency
+                value={(item.listPrice * item.quantity) / 100}
+              />
             </div>
           )}
           <div className="div fw6 fw5-m">
@@ -123,7 +127,9 @@ const ListItem: FunctionComponent<Props> = ({
       </div>
 
       {/* Remove - Desktop */}
-      <div className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}>
+      <div
+        className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}
+      >
         <div className="flex-auto">
           <button
             className="pointer bg-transparent bn pa2 ml6"


### PR DESCRIPTION
#### What problem is this solving?

This translates the "per un" text that shows up when an item has quantity greater than one.

#### How should this be manually tested?

[Workspace](https://productlist--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/18326/internacionalizar-termos-per-un-product-list).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

The translated text was broken into two `react-intl` messages because on a reduced width we don't want the line break to separate the "per un" text, so we wrapped each part in a `dib` class.