### PR TITLE
Send uniqueId instead of index on change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Change events now send the item's `uniqueId` instead of its `index`.
+
 ## [0.5.0] - 2019-08-27
 
 ### Changed

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -4,8 +4,8 @@ import ListItem from './components/ListItem'
 
 interface Props {
   items: Item[]
-  onQuantityChange: (index: number, value: number) => void
-  onRemove: (index: number) => void
+  onQuantityChange: (uniqueId: string, value: number) => void
+  onRemove: (uniqueId: string) => void
 }
 
 const ProductList: FunctionComponent<Props> = ({
@@ -14,12 +14,14 @@ const ProductList: FunctionComponent<Props> = ({
   onRemove,
 }) => (
   <div>
-    {items.map((item: any, index: number) => (
+    {items.map((item: any) => (
       <ListItem
-        key={index}
+        key={item.uniqueId}
         item={item}
-        onQuantityChange={(value: number) => onQuantityChange(index, value)}
-        onRemove={() => onRemove(index)}
+        onQuantityChange={(value: number) =>
+          onQuantityChange(item.uniqueId, value)
+        }
+        onRemove={() => onRemove(item.uniqueId)}
       />
     ))}
   </div>

--- a/react/__mocks__/mockItems.ts
+++ b/react/__mocks__/mockItems.ts
@@ -16,6 +16,7 @@ export const mockItems: Item[] = [
     sellingPrice: 2400000,
     skuName: 'Test SKU 0',
     skuSpecifications: [],
+    uniqueId: 'SomeUniqueId0',
   },
   {
     additionalInfo: {
@@ -34,6 +35,7 @@ export const mockItems: Item[] = [
     sellingPrice: 945000,
     skuName: 'Test SKU 1',
     skuSpecifications: [],
+    uniqueId: 'SomeUniqueId1',
   },
   {
     additionalInfo: {
@@ -52,5 +54,6 @@ export const mockItems: Item[] = [
     sellingPrice: 360000,
     skuName: 'Test SKU 2',
     skuSpecifications: [],
+    uniqueId: 'SomeUniqueId2',
   },
 ]

--- a/react/__mocks__/vtex.styleguide.tsx
+++ b/react/__mocks__/vtex.styleguide.tsx
@@ -1,7 +1,5 @@
-import Dropdown from '@vtex/styleguide/lib/Dropdown'
-import Input from '@vtex/styleguide/lib/Input'
-import Link from '@vtex/styleguide/lib/Link'
-import Spinner from '@vtex/styleguide/lib/Spinner'
-import IconDelete from '@vtex/styleguide/lib/icon/Delete'
-
-module.exports = { Input, Dropdown, Link, Spinner, IconDelete }
+export { default as Dropdown } from '@vtex/styleguide/lib/Dropdown'
+export { default as Input } from '@vtex/styleguide/lib/Input'
+export { default as Link } from '@vtex/styleguide/lib/Link'
+export { default as Spinner } from '@vtex/styleguide/lib/Spinner'
+export { default as IconDelete } from '@vtex/styleguide/lib/icon/Delete'

--- a/react/__tests__/ProductList.test.tsx
+++ b/react/__tests__/ProductList.test.tsx
@@ -11,7 +11,6 @@ describe('Product List', () => {
         items={mockItems}
         onQuantityChange={() => {}}
         onRemove={() => {}}
-        currency="USD"
       />
     )
 
@@ -21,14 +20,13 @@ describe('Product List', () => {
   })
 
   it('should call onRemove when remove button is clicked', async () => {
-    const mockHandleRemove = jest.fn((_: number) => {})
+    const mockHandleRemove = jest.fn((_: string) => {})
 
     const { findAllByTitle } = render(
       <ProductList
         items={mockItems}
         onQuantityChange={() => {}}
         onRemove={mockHandleRemove}
-        currency="USD"
       />
     )
 
@@ -37,7 +35,7 @@ describe('Product List', () => {
 
     fireEvent.click(removeButtons[1])
 
-    expect(mockHandleRemove.mock.calls.length).toBe(1)
-    expect(mockHandleRemove.mock.calls[0][0]).toBe(1)
+    expect(mockHandleRemove).toHaveBeenCalledTimes(1)
+    expect(mockHandleRemove.mock.calls[0][0]).toBe(mockItems[1].uniqueId)
   })
 })

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -12,6 +12,7 @@ interface Item {
   sellingPrice: number
   skuName: string
   skuSpecifications: SKUSpecification[]
+  uniqueId: string
 }
 
 interface ItemAdditionalInfo {


### PR DESCRIPTION
**Note:** _This PR depends on https://github.com/vtex-apps/checkout-cart/pull/12._

#### What problem is this solving?

Now that our GraphQL endpoint supports changing an item by its `uniqueId`, this PR changes the `product-list` to send the item's `uniqueId` instead of its `index` on change events.

#### How should this be manually tested?

[Workspace with `order-items`, `checkout-cart` and `product-list`](https://orderitems--vtexgame1.myvtex.com/cart).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/19188/possibilitar-alterar-itens-por-id).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
