### PR TITLE
Implement UI for unavailable items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- UI for unavailable items.
+
 ## [0.6.0] - 2019-09-05
 
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,6 @@
 {
+  "store/product-list.availableItems": "{quantity, plural, one {# available item} other {# available items}}",
+  "store/product-list.unavailableItems": "{quantity, plural, one {# unavailable item} other {# unavailable items}}",
   "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
   "store/product-list.pricePerUnit.measurementUnit": "per {measurementUnit}."
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,9 @@
 {
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "per {measurementUnit}.",
   "store/product-list.availableItems": "{quantity, plural, one {# available item} other {# available items}}",
   "store/product-list.unavailableItems": "{quantity, plural, one {# unavailable item} other {# unavailable items}}",
-  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
-  "store/product-list.pricePerUnit.measurementUnit": "per {measurementUnit}."
+  "store/product-list.message.cantBeDelivered": "This item cannot be delivered to this address.",
+  "store/product-list.message.noLongerAvailable": "This item is no longer available.",
+  "store/product-list.message.remove": "REMOVE"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,9 @@
 {
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}.",
   "store/product-list.availableItems": "{quantity, plural, one {# ítem disponible} other {# ítems disponibles}}",
   "store/product-list.unavailableItems": "{quantity, plural, one {# ítem no disponible} other {# ítems no disponibles}}",
-  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
-  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
+  "store/product-list.message.cantBeDelivered": "Este item no se puede entregar a esta dirección.",
+  "store/product-list.message.noLongerAvailable": "Este item no está disponible actualmente.",
+  "store/product-list.message.remove": "RETIRAR"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,6 @@
 {
+  "store/product-list.availableItems": "{quantity, plural, one {# ítem disponible} other {# ítems disponibles}}",
+  "store/product-list.unavailableItems": "{quantity, plural, one {# ítem no disponible} other {# ítems no disponibles}}",
   "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
   "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,6 @@
 {
+  "store/product-list.availableItems": "{quantity, plural, one {# item disponível} other {# itens disponíveis}}",
+  "store/product-list.unavailableItems": "{quantity, plural, one {# item indisponível} other {# itens indisponíveis}}",
   "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
   "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,9 @@
 {
+  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
+  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}.",
   "store/product-list.availableItems": "{quantity, plural, one {# item disponível} other {# itens disponíveis}}",
   "store/product-list.unavailableItems": "{quantity, plural, one {# item indisponível} other {# itens indisponíveis}}",
-  "store/product-list.pricePerUnit": "{price} {perMeasurementUnit}",
-  "store/product-list.pricePerUnit.measurementUnit": "por {measurementUnit}."
+  "store/product-list.message.cantBeDelivered": "Este item não pode ser entregue para este endereço.",
+  "store/product-list.message.noLongerAvailable": "Este item não está mais disponível.",
+  "store/product-list.message.remove": "REMOVER"
 }

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import ListItem from './components/ListItem'
-import Availability from './constants/Availability'
+import { AVAILABLE } from './constants/Availability'
 
 interface Props {
   items: Item[]
@@ -17,7 +17,7 @@ const ProductList: FunctionComponent<Props> = ({
 }) => {
   const [availableItems, unavailableItems] = items.reduce(
     (acc, item) => {
-      acc[item.availability === Availability.AVAILABLE ? 0 : 1].push(item)
+      acc[item.availability === AVAILABLE ? 0 : 1].push(item)
       return acc
     },
     [[], []] as Item[][]

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
 
 import ListItem from './components/ListItem'
 
@@ -12,9 +13,17 @@ const ProductList: FunctionComponent<Props> = ({
   items,
   onQuantityChange,
   onRemove,
-}) => (
-  <div>
-    {items.map((item: any) => (
+}) => {
+  const [availableItems, unavailableItems] = items.reduce(
+    (acc, item) => {
+      acc[item.availability === 'available' ? 0 : 1].push(item)
+      return acc
+    },
+    [[], []] as Item[][]
+  )
+
+  const productList = (itemList: Item[]) =>
+    itemList.map((item: Item) => (
       <ListItem
         key={item.uniqueId}
         item={item}
@@ -23,8 +32,30 @@ const ProductList: FunctionComponent<Props> = ({
         }
         onRemove={() => onRemove(item.uniqueId)}
       />
-    ))}
-  </div>
-)
+    ))
+
+  return (
+    <div>
+      {unavailableItems.length > 0 ? (
+        <div className="t-heading-4 bb b--muted-4">
+          <FormattedMessage
+            id="store/product-list.unavailableItems"
+            values={{ quantity: unavailableItems.length }}
+          />
+        </div>
+      ) : null}
+      {productList(unavailableItems)}
+      {availableItems.length > 0 ? (
+        <div className="t-heading-4 bb b--muted-4">
+          <FormattedMessage
+            id="store/product-list.availableItems"
+            values={{ quantity: availableItems.length }}
+          />
+        </div>
+      ) : null}
+      {productList(availableItems)}
+    </div>
+  )
+}
 
 export default ProductList

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import ListItem from './components/ListItem'
+import Availability from './constants/Availability'
 
 interface Props {
   items: Item[]
@@ -16,7 +17,7 @@ const ProductList: FunctionComponent<Props> = ({
 }) => {
   const [availableItems, unavailableItems] = items.reduce(
     (acc, item) => {
-      acc[item.availability === 'available' ? 0 : 1].push(item)
+      acc[item.availability === Availability.AVAILABLE ? 0 : 1].push(item)
       return acc
     },
     [[], []] as Item[][]
@@ -37,7 +38,7 @@ const ProductList: FunctionComponent<Props> = ({
   return (
     <div>
       {unavailableItems.length > 0 ? (
-        <div className="t-heading-4 bb b--muted-4">
+        <div className="c-muted-1 bb b--muted-4 fw5 pv5 pl5 pl6-m pl0-l t-heading-5-l">
           <FormattedMessage
             id="store/product-list.unavailableItems"
             values={{ quantity: unavailableItems.length }}
@@ -45,8 +46,8 @@ const ProductList: FunctionComponent<Props> = ({
         </div>
       ) : null}
       {productList(unavailableItems)}
-      {availableItems.length > 0 ? (
-        <div className="t-heading-4 bb b--muted-4">
+      {unavailableItems.length > 0 && availableItems.length > 0 ? (
+        <div className="c-muted-1 bb b--muted-4 fw5 mt7 pv5 pl5 pl6-m pl0-l t-heading-5-l">
           <FormattedMessage
             id="store/product-list.availableItems"
             values={{ quantity: availableItems.length }}

--- a/react/__mocks__/mockItems.ts
+++ b/react/__mocks__/mockItems.ts
@@ -3,6 +3,7 @@ export const mockItems: Item[] = [
     additionalInfo: {
       brandName: 'Test Brand 0',
     },
+    availability: 'available',
     id: '1',
     detailUrl: '/work-shirt/p',
     imageUrl:
@@ -22,6 +23,7 @@ export const mockItems: Item[] = [
     additionalInfo: {
       brandName: 'Test Brand 1',
     },
+    availability: 'withoutStock',
     id: '30',
     detailUrl: '/long-sleeve-shirt/p',
     imageUrl:
@@ -41,6 +43,7 @@ export const mockItems: Item[] = [
     additionalInfo: {
       brandName: 'Test Brand 2',
     },
+    availability: 'cannotBeDelivered',
     id: '2000535',
     detailUrl: '/classy--sunglasses/p',
     imageUrl:

--- a/react/__mocks__/vtex.styleguide.tsx
+++ b/react/__mocks__/vtex.styleguide.tsx
@@ -1,3 +1,4 @@
+export { default as Button } from '@vtex/styleguide/lib/Button'
 export { default as Dropdown } from '@vtex/styleguide/lib/Dropdown'
 export { default as Input } from '@vtex/styleguide/lib/Input'
 export { default as Link } from '@vtex/styleguide/lib/Link'

--- a/react/__tests__/ProductList.test.tsx
+++ b/react/__tests__/ProductList.test.tsx
@@ -5,8 +5,8 @@ import ProductList from '../ProductList'
 import { mockItems } from '../__mocks__/mockItems'
 
 describe('Product List', () => {
-  it('should display the list of products', async () => {
-    const { findByText } = render(
+  it('should display the list of products', () => {
+    const { queryByText } = render(
       <ProductList
         items={mockItems}
         onQuantityChange={() => {}}
@@ -14,28 +14,63 @@ describe('Product List', () => {
       />
     )
 
-    expect(await findByText(mockItems[0].name)).toBeTruthy()
-    expect(await findByText(mockItems[1].name)).toBeTruthy()
-    expect(await findByText(mockItems[2].name)).toBeTruthy()
+    expect(queryByText(mockItems[0].name)).toBeTruthy()
+    expect(queryByText(mockItems[1].name)).toBeTruthy()
+    expect(queryByText(mockItems[2].name)).toBeTruthy()
   })
 
-  it('should call onRemove when remove button is clicked', async () => {
+  it('should call onRemove when remove button is clicked', () => {
     const mockHandleRemove = jest.fn((_: string) => {})
 
-    const { findAllByTitle } = render(
+    const { getByTitle } = render(
       <ProductList
-        items={mockItems}
+        items={[mockItems[2]]}
         onQuantityChange={() => {}}
         onRemove={mockHandleRemove}
       />
     )
 
-    const removeButtons = (await findAllByTitle('remove')) as HTMLElement[]
-    expect(removeButtons.length).toBe(3)
-
-    fireEvent.click(removeButtons[1])
+    const removeButton = getByTitle('remove')
+    fireEvent.click(removeButton)
 
     expect(mockHandleRemove).toHaveBeenCalledTimes(1)
-    expect(mockHandleRemove.mock.calls[0][0]).toBe(mockItems[1].uniqueId)
+    expect(mockHandleRemove.mock.calls[0][0]).toBe(mockItems[2].uniqueId)
+  })
+
+  it('should display unavailable items separately', () => {
+    const { getByText } = render(
+      <ProductList
+        items={mockItems}
+        onQuantityChange={() => {}}
+        onRemove={() => {}}
+      />
+    )
+
+    expect(getByText('2 unavailable items')).toBeTruthy()
+    expect(getByText('1 available item')).toBeTruthy()
+  })
+
+  it('should display a message when item is out of stock', () => {
+    const { queryByText } = render(
+      <ProductList
+        items={[mockItems[1]]}
+        onQuantityChange={() => {}}
+        onRemove={() => {}}
+      />
+    )
+
+    expect(queryByText(/no longer available/)).toBeTruthy()
+  })
+
+  it('should display a message when item cannot be delivered', () => {
+    const { queryByText } = render(
+      <ProductList
+        items={[mockItems[2]]}
+        onQuantityChange={() => {}}
+        onRemove={() => {}}
+      />
+    )
+
+    expect(queryByText(/cannot be delivered/)).toBeTruthy()
   })
 })

--- a/react/components/AvailabilityMessage.tsx
+++ b/react/components/AvailabilityMessage.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
+import { Button } from 'vtex.styleguide'
+
+import Availability from '../constants/Availability'
+
+interface Props {
+  availability: string
+  onRemove: () => void
+}
+
+const AvailabilityMessage: FunctionComponent<Props> = ({
+  availability,
+  onRemove,
+}) => (
+  <div className="bg-warning--faded br2 flex-m justify-between">
+    <div className="self-center ph4 pt4 pt0-m">
+      {availability === Availability.CANNOT_BE_DELIVERED ? (
+        <FormattedMessage id="store/product-list.message.cantBeDelivered" />
+      ) : (
+        <FormattedMessage id="store/product-list.message.noLongerAvailable" />
+      )}
+    </div>
+    <div className="ph3">
+      <Button variation="tertiary" onClick={onRemove} collapseRight>
+        <FormattedMessage id="store/product-list.message.remove" />
+      </Button>
+    </div>
+  </div>
+)
+
+export default AvailabilityMessage

--- a/react/components/AvailabilityMessage.tsx
+++ b/react/components/AvailabilityMessage.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 
-import Availability from '../constants/Availability'
+import { CANNOT_BE_DELIVERED } from '../constants/Availability'
 
 interface Props {
   availability: string
@@ -15,7 +15,7 @@ const AvailabilityMessage: FunctionComponent<Props> = ({
 }) => (
   <div className="bg-warning--faded br2 flex-m justify-between">
     <div className="self-center ph4 pt4 pt0-m">
-      {availability === Availability.CANNOT_BE_DELIVERED ? (
+      {availability === CANNOT_BE_DELIVERED ? (
         <FormattedMessage id="store/product-list.message.cantBeDelivered" />
       ) : (
         <FormattedMessage id="store/product-list.message.noLongerAvailable" />

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -14,129 +14,137 @@ interface Props {
   onRemove: () => void
 }
 
+const displayOpaque = (item: Item) => {
+  return ['available', 'cannotBeDelivered'].includes(item.availability)
+    ? ''
+    : 'o-70'
+}
+
 const ListItem: FunctionComponent<Props> = ({
   item,
   onQuantityChange,
   onRemove,
 }) => (
-  <div className="c-on-base flex bb b--muted-4 ml5 pr5 pv5 ml6-m pt6-m pb6-m pr6-m ph0-l mh0-l">
-    {/* Image */}
-    <div className="flex-none mr5 mr6-m">
-      <a href={item.detailUrl}>
-        <img alt={item.name} src={item.imageUrl} width="100%" />
-      </a>
-    </div>
-
-    {/* Desktop Container */}
-    <div className="flex-auto flex-m">
-      {/* Product Info */}
-      <div className="flex-auto w-100 flex mb4 mr7-m">
-        {/* Brand and Name */}
-        <div className="flex-auto">
-          <div className="ttu f7 fw6 c-muted-1 mb2 fw5-m">
-            {item.additionalInfo.brandName}
-          </div>
-          <div>
-            <a
-              className="c-on-base t-title lh-copy fw6 no-underline fw5-m"
-              href={item.detailUrl}
-            >
-              {item.name}
-            </a>
-          </div>
-          {/* Variations */}
-          {item.skuSpecifications && item.skuSpecifications.length > 0 && (
-            <div className="mt2 c-muted-1 f6 lh-copy">
-              {item.skuSpecifications.map(
-                (spec: SKUSpecification, idx: number) => {
-                  return (
-                    <div key={idx}>
-                      {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
-                    </div>
-                  )
-                }
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Remove - Mobile */}
-        <div className="flex-none dn-m">
-          <button
-            className="bg-transparent bn pa2 mt4-m ml4"
-            title="remove"
-            onClick={onRemove}
-          >
-            <IconDelete color="#727273" />
-          </button>
-        </div>
+  <div className="bb b--muted-4">
+    <div className={`c-on-base flex ml5 pr5 pv5 ml6-m pt6-m pb6-m pr6-m ph0-l mh0-l ${displayOpaque(item)}`}>
+      {/* Image */}
+      <div className="flex-none mr5 mr6-m">
+        <a href={item.detailUrl}>
+          <img alt={item.name} src={item.imageUrl} width="100%" />
+        </a>
       </div>
 
-      {/* Quantity Selector */}
-      <div className={`${styles.quantity} flex-none-m`}>
-        <div className={`${styles.quantitySelector}`}>
-          <Selector
-            value={item.quantity}
-            maxValue={MAX_ITEM_QUANTITY}
-            onChange={onQuantityChange}
-          />
+      {/* Desktop Container */}
+      <div className="flex-auto flex-m">
+        {/* Product Info */}
+        <div className="flex-auto w-100 flex mb4 mr7-m">
+          {/* Brand and Name */}
+          <div className="flex-auto">
+            <div className="ttu f7 fw6 c-muted-1 mb2 fw5-m">
+              {item.additionalInfo.brandName}
+            </div>
+            <div>
+              <a
+                className="c-on-base t-title lh-copy fw6 no-underline fw5-m"
+                href={item.detailUrl}
+              >
+                {item.name}
+              </a>
+            </div>
+            {/* Variations */}
+            {item.skuSpecifications && item.skuSpecifications.length > 0 && (
+              <div className="mt2 c-muted-1 f6 lh-copy">
+                {item.skuSpecifications.map(
+                  (spec: SKUSpecification, idx: number) => {
+                    return (
+                      <div key={idx}>
+                        {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
+                      </div>
+                    )
+                  }
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Remove - Mobile */}
+          <div className="flex-none dn-m">
+            <button
+              className="bg-transparent bn pa2 mt4-m ml4"
+              title="remove"
+              onClick={onRemove}
+            >
+              <IconDelete color="#727273" />
+            </button>
+          </div>
         </div>
 
-        {item.quantity > 1 && (
-          <div className="mt3 t-mini c-muted-1 tc-m lh-title">
-            <FormattedMessage
-              id="store/product-list.pricePerUnit"
-              values={{
-                price: (
-                  <div className="dib">
-                    <FormattedCurrency value={item.sellingPrice / 100} />
-                  </div>
-                ),
-                perMeasurementUnit: (
-                  <div className="dib">
-                    <FormattedMessage
-                      id="store/product-list.pricePerUnit.measurementUnit"
-                      values={{ measurementUnit: item.measurementUnit }}
-                    />
-                  </div>
-                ),
-              }}
+        {/* Quantity Selector */}
+        <div className={`${styles.quantity} flex-none-m`}>
+          <div className={`${styles.quantitySelector}`}>
+            <Selector
+              value={item.quantity}
+              maxValue={MAX_ITEM_QUANTITY}
+              onChange={onQuantityChange}
             />
           </div>
-        )}
-      </div>
 
-      {/* Price */}
-      <div
-        className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}
-      >
-        <div className="flex-auto">
-          {item.listPrice !== item.price && (
-            <div className="c-muted-1 strike t-mini mb2">
-              <FormattedCurrency
-                value={(item.listPrice * item.quantity) / 100}
+          {item.quantity > 1 && (
+            <div className="mt3 t-mini c-muted-1 tc-m lh-title">
+              <FormattedMessage
+                id="store/product-list.pricePerUnit"
+                values={{
+                  price: (
+                    <div className="dib">
+                      <FormattedCurrency value={item.sellingPrice / 100} />
+                    </div>
+                  ),
+                  perMeasurementUnit: (
+                    <div className="dib">
+                      <FormattedMessage
+                        id="store/product-list.pricePerUnit.measurementUnit"
+                            values={{ measurementUnit: item.measurementUnit }}
+                      />
+                    </div>
+                  ),
+                }}
               />
             </div>
           )}
-          <div className="div fw6 fw5-m">
-            <FormattedCurrency
-              value={(item.sellingPrice * item.quantity) / 100}
-            />
+        </div>
+
+        {/* Price */}
+        <div
+          className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}
+        >
+          <div className="flex-auto">
+            {item.listPrice !== item.price && (
+              <div className="c-muted-1 strike t-mini mb2">
+                <FormattedCurrency
+                  value={(item.listPrice * item.quantity) / 100}
+                />
+              </div>
+            )}
+            <div className="div fw6 fw5-m">
+              <FormattedCurrency
+                value={(item.sellingPrice * item.quantity) / 100}
+              />
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Remove - Desktop */}
-      <div
-        className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}
-      >
-        <div className="flex-auto">
-          <button
-            className="pointer bg-transparent bn pa2 ml6"
-            onClick={onRemove}
-          >
-            <IconDelete color="#727273" />
-          </button>
+        {/* Remove - Desktop */}
+        <div
+          className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}
+        >
+          <div className="flex-auto">
+            <button
+              className="pointer bg-transparent bn pa2 ml6"
+              onClick={onRemove}
+            >
+              <IconDelete color="#727273" />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -3,6 +3,8 @@ import { FormattedMessage } from 'react-intl'
 import { IconDelete } from 'vtex.styleguide'
 import { FormattedCurrency } from 'vtex.format-currency'
 
+import Availability from '../constants/Availability'
+import AvailabilityMessage from './AvailabilityMessage'
 import Selector from './QuantitySelector'
 
 const MAX_ITEM_QUANTITY = 99999
@@ -14,10 +16,8 @@ interface Props {
   onRemove: () => void
 }
 
-const displayOpaque = (item: Item) => {
-  return ['available', 'cannotBeDelivered'].includes(item.availability)
-    ? ''
-    : 'o-70'
+const displayOpaque = (availability: string) => {
+  return availability === Availability.WITHOUT_STOCK ? 'o-70' : ''
 }
 
 const ListItem: FunctionComponent<Props> = ({
@@ -26,126 +26,142 @@ const ListItem: FunctionComponent<Props> = ({
   onRemove,
 }) => (
   <div className="bb b--muted-4">
-    <div className={`c-on-base flex ml5 pr5 pv5 ml6-m pt6-m pb6-m pr6-m ph0-l mh0-l ${displayOpaque(item)}`}>
+    <div
+      className={`c-on-base flex ml5 pr5 pv5 ml6-m pt6-m pb6-m pr6-m ph0-l mh0-l`}
+    >
       {/* Image */}
-      <div className="flex-none mr5 mr6-m">
+      <div
+        className={`flex-none mr5 mr6-m ${displayOpaque(item.availability)}`}
+      >
         <a href={item.detailUrl}>
           <img alt={item.name} src={item.imageUrl} width="100%" />
         </a>
       </div>
 
       {/* Desktop Container */}
-      <div className="flex-auto flex-m">
-        {/* Product Info */}
-        <div className="flex-auto w-100 flex mb4 mr7-m">
-          {/* Brand and Name */}
-          <div className="flex-auto">
-            <div className="ttu f7 fw6 c-muted-1 mb2 fw5-m">
-              {item.additionalInfo.brandName}
-            </div>
-            <div>
-              <a
-                className="c-on-base t-title lh-copy fw6 no-underline fw5-m"
-                href={item.detailUrl}
-              >
-                {item.name}
-              </a>
-            </div>
-            {/* Variations */}
-            {item.skuSpecifications && item.skuSpecifications.length > 0 && (
-              <div className="mt2 c-muted-1 f6 lh-copy">
-                {item.skuSpecifications.map(
-                  (spec: SKUSpecification, idx: number) => {
-                    return (
-                      <div key={idx}>
-                        {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
-                      </div>
-                    )
-                  }
-                )}
+      <div className="flex-auto">
+        <div className={`flex-auto flex-m ${displayOpaque(item.availability)}`}>
+          {/* Product Info */}
+          <div className="flex-auto w-100 flex mb4 mr7-m">
+            {/* Brand and Name */}
+            <div className="flex-auto">
+              <div className="ttu f7 fw6 c-muted-1 mb2 fw5-m">
+                {item.additionalInfo.brandName}
               </div>
-            )}
+              <div>
+                <a
+                  className="c-on-base t-title lh-copy fw6 no-underline fw5-m"
+                  href={item.detailUrl}
+                >
+                  {item.name}
+                </a>
+              </div>
+              {/* Variations */}
+              {item.skuSpecifications && item.skuSpecifications.length > 0 && (
+                <div className="mt2 c-muted-1 f6 lh-copy">
+                  {item.skuSpecifications.map(
+                    (spec: SKUSpecification, idx: number) => {
+                      return (
+                        <div key={idx}>
+                          {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
+                        </div>
+                      )
+                    }
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Remove - Mobile */}
+            <div className="flex-none dn-m">
+              <button
+                className="bg-transparent bn pa2 mt4-m ml4"
+                title="remove"
+                onClick={onRemove}
+              >
+                <IconDelete color="#727273" />
+              </button>
+            </div>
           </div>
 
-          {/* Remove - Mobile */}
-          <div className="flex-none dn-m">
-            <button
-              className="bg-transparent bn pa2 mt4-m ml4"
-              title="remove"
-              onClick={onRemove}
-            >
-              <IconDelete color="#727273" />
-            </button>
-          </div>
-        </div>
-
-        {/* Quantity Selector */}
-        <div className={`${styles.quantity} flex-none-m`}>
-          <div className={`${styles.quantitySelector}`}>
-            <Selector
-              value={item.quantity}
-              maxValue={MAX_ITEM_QUANTITY}
-              onChange={onQuantityChange}
-            />
-          </div>
-
-          {item.quantity > 1 && (
-            <div className="mt3 t-mini c-muted-1 tc-m lh-title">
-              <FormattedMessage
-                id="store/product-list.pricePerUnit"
-                values={{
-                  price: (
-                    <div className="dib">
-                      <FormattedCurrency value={item.sellingPrice / 100} />
-                    </div>
-                  ),
-                  perMeasurementUnit: (
-                    <div className="dib">
-                      <FormattedMessage
-                        id="store/product-list.pricePerUnit.measurementUnit"
-                            values={{ measurementUnit: item.measurementUnit }}
-                      />
-                    </div>
-                  ),
-                }}
+          {/* Quantity Selector */}
+          <div className={`${styles.quantity} flex-none-m`}>
+            <div className={`${styles.quantitySelector}`}>
+              <Selector
+                value={item.quantity}
+                maxValue={MAX_ITEM_QUANTITY}
+                onChange={onQuantityChange}
+                disabled={item.availability !== 'available'}
               />
             </div>
-          )}
-        </div>
 
-        {/* Price */}
-        <div
-          className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}
-        >
-          <div className="flex-auto">
-            {item.listPrice !== item.price && (
-              <div className="c-muted-1 strike t-mini mb2">
-                <FormattedCurrency
-                  value={(item.listPrice * item.quantity) / 100}
+            {item.quantity > 1 && (
+              <div className="mt3 t-mini c-muted-1 tc-m lh-title">
+                <FormattedMessage
+                  id="store/product-list.pricePerUnit"
+                  values={{
+                    price: (
+                      <div className="dib">
+                        <FormattedCurrency value={item.sellingPrice / 100} />
+                      </div>
+                    ),
+                    perMeasurementUnit: (
+                      <div className="dib">
+                        <FormattedMessage
+                          id="store/product-list.pricePerUnit.measurementUnit"
+                          values={{ measurementUnit: item.measurementUnit }}
+                        />
+                      </div>
+                    ),
+                  }}
                 />
               </div>
             )}
-            <div className="div fw6 fw5-m">
-              <FormattedCurrency
-                value={(item.sellingPrice * item.quantity) / 100}
-              />
+          </div>
+
+          {/* Price */}
+          <div
+            className={`${styles.price} mt5 mt0-ns flex-m items-center-m tr-m flex-none-m ml5-m`}
+          >
+            <div className="flex-auto">
+              {item.listPrice !== item.price && (
+                <div className="c-muted-1 strike t-mini mb2">
+                  <FormattedCurrency
+                    value={(item.listPrice * item.quantity) / 100}
+                  />
+                </div>
+              )}
+              <div className="div fw6 fw5-m">
+                <FormattedCurrency
+                  value={(item.sellingPrice * item.quantity) / 100}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Remove - Desktop */}
+          <div
+            className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}
+          >
+            <div className="flex-auto">
+              <button
+                className="pointer bg-transparent bn pa2 ml6"
+                onClick={onRemove}
+              >
+                <IconDelete color="#727273" />
+              </button>
             </div>
           </div>
         </div>
 
-        {/* Remove - Desktop */}
-        <div
-          className={`${styles.remove} flex-m items-center-m flex-none-m dn db-m`}
-        >
-          <div className="flex-auto">
-            <button
-              className="pointer bg-transparent bn pa2 ml6"
-              onClick={onRemove}
-            >
-              <IconDelete color="#727273" />
-            </button>
+        {item.availability !== 'available' ? (
+          <div className="mt4">
+            <AvailabilityMessage
+              availability={item.availability}
+              onRemove={onRemove}
+            />
           </div>
-        </div>
+        ) : null}
       </div>
     </div>
   </div>

--- a/react/components/ListItem.tsx
+++ b/react/components/ListItem.tsx
@@ -3,7 +3,7 @@ import { FormattedMessage } from 'react-intl'
 import { IconDelete } from 'vtex.styleguide'
 import { FormattedCurrency } from 'vtex.format-currency'
 
-import Availability from '../constants/Availability'
+import { AVAILABLE, WITHOUT_STOCK } from '../constants/Availability'
 import AvailabilityMessage from './AvailabilityMessage'
 import Selector from './QuantitySelector'
 
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const displayOpaque = (availability: string) => {
-  return availability === Availability.WITHOUT_STOCK ? 'o-70' : ''
+  return availability === WITHOUT_STOCK ? 'o-70' : ''
 }
 
 const ListItem: FunctionComponent<Props> = ({
@@ -91,7 +91,7 @@ const ListItem: FunctionComponent<Props> = ({
                 value={item.quantity}
                 maxValue={MAX_ITEM_QUANTITY}
                 onChange={onQuantityChange}
-                disabled={item.availability !== 'available'}
+                disabled={item.availability !== AVAILABLE}
               />
             </div>
 
@@ -154,7 +154,7 @@ const ListItem: FunctionComponent<Props> = ({
           </div>
         </div>
 
-        {item.availability !== 'available' ? (
+        {item.availability !== AVAILABLE ? (
           <div className="mt4">
             <AvailabilityMessage
               availability={item.availability}

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -13,6 +13,7 @@ interface Props {
   value: number
   maxValue: number
   onChange: (value: number) => void
+  disabled: boolean
 }
 
 const normalizeValue = (value: number, maxValue: number) =>
@@ -55,6 +56,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
   value,
   maxValue,
   onChange,
+  disabled,
 }) => {
   const [curSelector, setSelector] = useState(
     value < 10 ? SelectorType.Dropdown : SelectorType.Input
@@ -101,6 +103,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
             value={normalizedValue}
             onChange={(event: any) => handleChange(event.target.value)}
             placeholder=""
+            disabled={disabled}
           />
         </div>
         <div className="dn db-m">
@@ -109,6 +112,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
             value={normalizedValue}
             onChange={(event: any) => handleChange(event.target.value)}
             placeholder=""
+            disabled={disabled}
           />
         </div>
       </div>
@@ -124,6 +128,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""
+            disabled={disabled}
           />
         </div>
         <div className="dn db-m">
@@ -133,6 +138,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
             onChange={(event: any) => handleChange(event.target.value)}
             onBlur={handleBlur}
             placeholder=""
+            disabled={disabled}
           />
         </div>
       </div>

--- a/react/constants/Availability.ts
+++ b/react/constants/Availability.ts
@@ -1,0 +1,5 @@
+export default {
+  AVAILABLE: 'available',
+  CANNOT_BE_DELIVERED: 'cannotBeDelivered',
+  WITHOUT_STOCK: 'withoutStock',
+}

--- a/react/constants/Availability.ts
+++ b/react/constants/Availability.ts
@@ -1,5 +1,3 @@
-export default {
-  AVAILABLE: 'available',
-  CANNOT_BE_DELIVERED: 'cannotBeDelivered',
-  WITHOUT_STOCK: 'withoutStock',
-}
+export const AVAILABLE = 'available'
+export const CANNOT_BE_DELIVERED = 'cannotBeDelivered'
+export const WITHOUT_STOCK = 'withoutStock'

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,5 +1,6 @@
 interface Item {
   additionalInfo: ItemAdditionalInfo
+  availability: string
   detailUrl: string
   id: string
   imageUrl: string


### PR DESCRIPTION
#### What problem is this solving?

This PR:
- Displays unavailable and available items separately;
- Displays a message explaining why the item is unavailable.

#### How should this be manually tested?

[Use this workspace](https://unavailable--vtexgame1.myvtex.com/cart).
Add [this item](https://unavailable--vtexgame1.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p) and [this item](https://unavailable--vtexgame1.myvtex.com/produto-variacao/p?skuId=14) to your cart, proceed to the _**old**_ checkout (`/checkout`) and set delivery to somewhere in SP (you can use 04538-132). This makes the second item unavailable. Now proceed to `/cart` and verify the product-list behaves as expected.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/18328/implementar-ui-dos-erros-de-disponibilidade-product-list).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![Screen Shot 2019-09-06 at 3 29 33 PM](https://user-images.githubusercontent.com/8902498/64451781-4b29c080-d0bb-11e9-9351-f9eeeaeafa58.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
