### PR TITLE
Fix tests and add GitHub action to run them

### DIFF
--- a/.github/workflows/test-react.yml
+++ b/.github/workflows/test-react.yml
@@ -1,0 +1,25 @@
+name: Test CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test-react:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Run React tests
+      run: |
+        cd react
+        yarn
+        yarn test --passWithNoTests
+      env:
+        CI: true

--- a/react/RemoveButton.tsx
+++ b/react/RemoveButton.tsx
@@ -9,7 +9,11 @@ const RemoveButton: FunctionComponent = () => {
 
   return (
     <div className={opaque(item.availability)}>
-      <button className="pointer bg-transparent bn pa2 ml6" onClick={onRemove}>
+      <button
+        className="pointer bg-transparent bn pa2 ml6"
+        title="remove"
+        onClick={onRemove}
+      >
         <IconDelete color="#727273" />
       </button>
     </div>

--- a/react/__tests__/ProductList.test.tsx
+++ b/react/__tests__/ProductList.test.tsx
@@ -1,8 +1,31 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { render, fireEvent } from '@vtex/test-tools/react'
 
-import ProductList from '../ProductList'
 import { mockItems } from '../__mocks__/mockItems'
+import AvailabilityMessage from '../AvailabilityMessage'
+import Image from '../Image'
+import Price from '../Price'
+import ProductBrand from '../ProductBrand'
+import ProductList from '../ProductList'
+import ProductName from '../ProductName'
+import ProductVariations from '../ProductVariations'
+import QuantitySelector from '../QuantitySelector'
+import RemoveButton from '../RemoveButton'
+import UnitPrice from '../UnitPrice'
+
+const ListItem: FunctionComponent = () => (
+  <div>
+    <AvailabilityMessage layout="cols" />
+    <Image />
+    <Price textAlign="left" />
+    <ProductBrand />
+    <ProductName />
+    <ProductVariations />
+    <QuantitySelector />
+    <RemoveButton />
+    <UnitPrice textAlign="left" />
+  </div>
+)
 
 describe('Product List', () => {
   it('should display the list of products', () => {
@@ -11,6 +34,7 @@ describe('Product List', () => {
         items={mockItems}
         onQuantityChange={() => {}}
         onRemove={() => {}}
+        children={<ListItem />}
       />
     )
 
@@ -27,6 +51,7 @@ describe('Product List', () => {
         items={[mockItems[2]]}
         onQuantityChange={() => {}}
         onRemove={mockHandleRemove}
+        children={<ListItem />}
       />
     )
 
@@ -43,6 +68,7 @@ describe('Product List', () => {
         items={mockItems}
         onQuantityChange={() => {}}
         onRemove={() => {}}
+        children={<ListItem />}
       />
     )
 
@@ -56,6 +82,7 @@ describe('Product List', () => {
         items={[mockItems[1]]}
         onQuantityChange={() => {}}
         onRemove={() => {}}
+        children={<ListItem />}
       />
     )
 
@@ -68,6 +95,7 @@ describe('Product List', () => {
         items={[mockItems[2]]}
         onQuantityChange={() => {}}
         onRemove={() => {}}
+        children={<ListItem />}
       />
     )
 


### PR DESCRIPTION
#### What problem is this solving?

Tests were broken after the PR that introduced `flex-layout`. This PR fixes the tests by creating a test component that contains all smaller components that compose an item of the product list, since it doesn't seem to be currently possible to generate locally the full component that results from the blocks framework. This also adds a GitHub action that runs React tests.

#### How should this be manually tested?

`yarn test`, and the Checks tab of this PR.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [x] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
