### PR TITLE
Treat case when item sellingPrice is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When the selling price of an item is zero, the text "FREE" is shown in place of the price and the price per unit is not shown, even when the item quantity is greater than one.
+
 ## [0.9.0] - 2019-10-04
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.format-currency": "0.x",
+    "vtex.formatted-price": "0.x",
     "vtex.flex-layout": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FormattedCurrency } from 'vtex.format-currency'
+import { FormattedPrice } from 'vtex.formatted-price'
 
 import { useItemContext } from './components/ItemContext'
 import { opaque } from './utils/opaque'
@@ -23,9 +24,7 @@ const Price: StorefrontFunctionComponent<TextAlignProp> = ({ textAlign }) => {
           </div>
         )}
         <div className="div fw6 fw5-m">
-          <FormattedCurrency
-            value={(item.sellingPrice * item.quantity) / 100}
-          />
+          <FormattedPrice value={(item.sellingPrice * item.quantity) / 100} />
         </div>
       </div>
     </div>

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -12,7 +12,7 @@ const UnitPrice: StorefrontFunctionComponent<TextAlignProp> = ({
 }) => {
   const { item } = useItemContext()
 
-  return item.quantity > 1 ? (
+  return item.quantity > 1 && item.sellingPrice > 0 ? (
     <div
       className={`t-mini c-muted-1 lh-title ${styles.quantity} ${opaque(
         item.availability

--- a/react/__mocks__/vtex.formatted-price.tsx
+++ b/react/__mocks__/vtex.formatted-price.tsx
@@ -1,0 +1,9 @@
+import React, { FunctionComponent } from 'react'
+
+interface Props {
+  value: number
+}
+
+export const FormattedPrice: FunctionComponent<Props> = ({ value }) => (
+  <div>{value}</div>
+)


### PR DESCRIPTION
#### What problem is this solving?

This changes the behavior of the product list when the selling price of an item is zero:
- It displays "FREE" in green text instead of the value 0 in the corresponding currency;
- The unit price does not show even when the item quantity is greater than one.

#### How should this be manually tested?

Use [this workspace](https://free--vtexgame1.myvtex.com/). Add any item to cart twice, then go to `/cart`. Apply the `testegratis` coupon and verify the behavior described above.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23493/ajustes-nos-itens-da-lista-de-produtos-em-caso-de-valor-zerado).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
