### PR TITLE
Allow value 0 in quantity selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Quantity selector now allows selecting the value zero.
+
+### Fixed
+
+- Bug that caused the component to crash when a negative number was input into the quantity selector.
+
 ## [0.10.0] - 2019-10-10
 
 ### Changed

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -22,7 +22,7 @@ const normalizeValue = (value: number, maxValue: number) =>
 const validateValue = (value: string, maxValue: number) => {
   const parsedValue = parseInt(value, 10)
 
-  if (isNaN(parsedValue) || parsedValue === 0) {
+  if (isNaN(parsedValue)) {
     return 1
   }
 
@@ -32,7 +32,7 @@ const validateValue = (value: string, maxValue: number) => {
 const validateDisplayValue = (value: string, maxValue: number) => {
   const parsedValue = parseInt(value, 10)
 
-  if (isNaN(parsedValue) || parsedValue < 1) {
+  if (isNaN(parsedValue) || parsedValue < 0) {
     return ''
   }
 
@@ -42,6 +42,7 @@ const validateDisplayValue = (value: string, maxValue: number) => {
 const getDropdownOptions = (maxValue: number) => {
   const limit = Math.min(9, maxValue)
   const options = [
+    { value: 0, label: '0' },
     ...range(1, limit + 1).map(idx => ({ value: idx, label: `${idx}` })),
   ]
 
@@ -61,12 +62,13 @@ const QuantitySelector: FunctionComponent<Props> = ({
   const [curSelector, setSelector] = useState(
     value < 10 ? SelectorType.Dropdown : SelectorType.Input
   )
+  const [activeInput, setActiveInput] = useState(false)
 
   const normalizedValue = normalizeValue(value, maxValue)
 
   const [curDisplayValue, setDisplayValue] = useState(`${normalizedValue}`)
 
-  const handleChange = (value: string) => {
+  const handleDropdownChange = (value: string) => {
     const validatedValue = validateValue(value, maxValue)
     const displayValue = validateDisplayValue(value, maxValue)
 
@@ -78,13 +80,28 @@ const QuantitySelector: FunctionComponent<Props> = ({
     onChange(validatedValue)
   }
 
-  const handleBlur = () => {
+  const handleInputChange = (value: string) => {
+    const displayValue = validateDisplayValue(value, maxValue)
+
+    setDisplayValue(displayValue)
+  }
+
+  const handleInputBlur = () => {
+    setActiveInput(false)
     if (curDisplayValue === '') {
       setDisplayValue('1')
     }
+
+    const validatedValue = validateValue(curDisplayValue, maxValue)
+    onChange(validatedValue)
   }
 
-  if (normalizedValue !== validateValue(curDisplayValue, maxValue)) {
+  const handleInputFocus = () => setActiveInput(true)
+
+  if (
+    !activeInput &&
+    normalizedValue !== validateValue(curDisplayValue, maxValue)
+  ) {
     if (normalizedValue >= 10) {
       setSelector(SelectorType.Input)
     }
@@ -101,7 +118,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
             options={dropdownOptions}
             size="small"
             value={normalizedValue}
-            onChange={(event: any) => handleChange(event.target.value)}
+            onChange={(event: any) => handleDropdownChange(event.target.value)}
             placeholder=""
             disabled={disabled}
           />
@@ -110,7 +127,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
           <Dropdown
             options={dropdownOptions}
             value={normalizedValue}
-            onChange={(event: any) => handleChange(event.target.value)}
+            onChange={(event: any) => handleDropdownChange(event.target.value)}
             placeholder=""
             disabled={disabled}
           />
@@ -125,8 +142,9 @@ const QuantitySelector: FunctionComponent<Props> = ({
             size="small"
             value={curDisplayValue}
             maxLength={MAX_INPUT_LENGTH}
-            onChange={(event: any) => handleChange(event.target.value)}
-            onBlur={handleBlur}
+            onChange={(event: any) => handleInputChange(event.target.value)}
+            onBlur={handleInputBlur}
+            onFocus={handleInputFocus}
             placeholder=""
             disabled={disabled}
           />
@@ -135,8 +153,9 @@ const QuantitySelector: FunctionComponent<Props> = ({
           <Input
             value={curDisplayValue}
             maxLength={MAX_INPUT_LENGTH}
-            onChange={(event: any) => handleChange(event.target.value)}
-            onBlur={handleBlur}
+            onChange={(event: any) => handleInputChange(event.target.value)}
+            onBlur={handleInputBlur}
+            onFocus={handleInputFocus}
             placeholder=""
             disabled={disabled}
           />


### PR DESCRIPTION
#### What problem is this solving?

We want to allow users to set the quantity of some item to 0 as an alternative way of removing it from the cart. Currently, the selector does not allow that. The reason is that when the quantity selector is in Input mode, the selector calls `onChange` after each key press. As a result, if the user presses 0, the item would be instantly removed from the cart, which is probably not their intention.

This PR changes the way the Input of the quantity selector behaves. Instead of calling `onChange` after each key press, it waits until the component is blurred before registering the change and updating the UI with the new value, which I believe is a more natural behavior and solves the issue mentioned before.

As a bonus, this also fixes the bug that crashes the component when the Input receives a negative value.

#### How should this be manually tested?

Add [some item](https://quantity--vtexgame1.myvtex.com/camisa-vasco-preta/p) then go to `/cart` and interact with the quantity selector.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable) [[1]](https://app.clubhouse.io/vtex/story/23742/permitir-quantidade-0-no-carrinho-como-outra-forma-de-excluir-produtos) [[2]](https://app.clubhouse.io/vtex/story/23473/product-list-quebra-quando-é-selecionado-uma-quantidade-negativa-de-um-item).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

We still need to add some kind of confirmation when removing an item or allowing the user to undo the removal action. This still needs some discussion so I'll leave that to a future PR.
