### PR TITLE
Fix product name unintentionally repositioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug that caused the product name to move slightly when the selected quantity changed between 1 and any other number.
+
 ## [0.11.0] - 2019-10-16
 
 ### Changed

--- a/store/blocks/common.json
+++ b/store/blocks/common.json
@@ -7,7 +7,8 @@
     ],
     "props": {
       "marginBottom": "5",
-      "width": "grow"
+      "width": "grow",
+      "preventVerticalStretch": "true"
     }
   },
   "flex-layout.row#product-brand": {


### PR DESCRIPTION
#### What problem is this solving?

When the selected quantity of an item changes between 1 and any other number, the product name moves vertically a little bit. This PR fixes this issue by setting to `true` the `preventVerticalStretch` prop of the block that contains the product description.

#### How should this be manually tested?

Add [some item](https://name--vtexgame1.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p), then go to `/cart` and interact with the quantity selector.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/23908/na-miniatura-de-produto-o-nome-do-produto-é-reposicionado-após-alteração-de-quantidade).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
