### PR TITLE
Add ids to Styleguide components and HTML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `ids` to Styleguide components and HTML elements.
+
 ## [0.11.1] - 2019-10-16
 
 ### Fixed

--- a/react/AvailabilityMessage.tsx
+++ b/react/AvailabilityMessage.tsx
@@ -49,7 +49,12 @@ const AvailabilityMessage: StorefrontFunctionComponent<Props> = ({
         )}
       </div>
       <div className="ph3">
-        <Button variation="tertiary" onClick={onRemove} collapseRight>
+        <Button
+          id="availability-remove-button"
+          variation="tertiary"
+          onClick={onRemove}
+          collapseRight
+        >
           <FormattedMessage id="store/product-list.message.remove" />
         </Button>
       </div>

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -8,7 +8,11 @@ const Image: FunctionComponent = () => {
   const { item } = useItemContext()
 
   return (
-    <div className={opaque(item.availability)} style={{ minWidth: '96px' }}>
+    <div
+      id={`${item.id}-image`}
+      className={opaque(item.availability)}
+      style={{ minWidth: '96px' }}
+    >
       <a href={item.detailUrl}>
         {item.imageUrl ? (
           <img

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -19,11 +19,14 @@ const Price: StorefrontFunctionComponent<TextAlignProp> = ({ textAlign }) => {
     >
       <div>
         {item.listPrice !== item.price && (
-          <div className="c-muted-1 strike t-mini mb2">
+          <div
+            id={`${item.id}-list-price`}
+            className="c-muted-1 strike t-mini mb2"
+          >
             <FormattedCurrency value={(item.listPrice * item.quantity) / 100} />
           </div>
         )}
-        <div className="div fw6 fw5-m">
+        <div id={`${item.id}-price`} className="div fw6 fw5-m">
           <FormattedPrice value={(item.sellingPrice * item.quantity) / 100} />
         </div>
       </div>

--- a/react/ProductBrand.tsx
+++ b/react/ProductBrand.tsx
@@ -7,7 +7,10 @@ const ProductBrand: FunctionComponent = () => {
   const { item } = useItemContext()
 
   return (
-    <div className={`ttu f7 fw6 c-muted-1 fw5-m ${opaque(item.availability)}`}>
+    <div
+      id={`${item.id}-brand-name`}
+      className={`ttu f7 fw6 c-muted-1 fw5-m ${opaque(item.availability)}`}
+    >
       {item.additionalInfo.brandName}
     </div>
   )

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -42,7 +42,10 @@ const ProductList: StorefrontFunctionComponent<Props> = ({
   return (
     <div>
       {unavailableItems.length > 0 ? (
-        <div className="c-muted-1 bb b--muted-4 fw5 pv5 pl5 pl6-m pl0-l t-heading-5-l">
+        <div
+          id="unavailable-items"
+          className="c-muted-1 bb b--muted-4 fw5 pv5 pl5 pl6-m pl0-l t-heading-5-l"
+        >
           <FormattedMessage
             id="store/product-list.unavailableItems"
             values={{ quantity: unavailableItems.length }}

--- a/react/ProductName.tsx
+++ b/react/ProductName.tsx
@@ -8,6 +8,7 @@ const ProductName: FunctionComponent = () => {
 
   return (
     <a
+      id={`${item.id}-name`}
       className={`c-on-base t-title lh-copy fw6 no-underline fw5-m ${opaque(
         item.availability
       )}`}

--- a/react/ProductVariations.tsx
+++ b/react/ProductVariations.tsx
@@ -10,7 +10,7 @@ const ProductVariations: FunctionComponent = () => {
     <div className={`c-muted-1 f6 lh-copy ${opaque(item.availability)}`}>
       {item.skuSpecifications.map((spec: SKUSpecification, idx: number) => {
         return (
-          <div key={idx}>
+          <div id={`${idx}`} key={idx}>
             {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
           </div>
         )

--- a/react/ProductVariations.tsx
+++ b/react/ProductVariations.tsx
@@ -10,7 +10,10 @@ const ProductVariations: FunctionComponent = () => {
     <div className={`c-muted-1 f6 lh-copy ${opaque(item.availability)}`}>
       {item.skuSpecifications.map((spec: SKUSpecification, idx: number) => {
         return (
-          <div id={`${idx}`} key={idx}>
+          <div
+            id={`${idx}-${spec.fieldName}-specification`}
+            key={`${spec.fieldName}-key`}
+          >
             {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
           </div>
         )

--- a/react/ProductVariations.tsx
+++ b/react/ProductVariations.tsx
@@ -8,10 +8,10 @@ const ProductVariations: FunctionComponent = () => {
 
   return item.skuSpecifications && item.skuSpecifications.length > 0 ? (
     <div className={`c-muted-1 f6 lh-copy ${opaque(item.availability)}`}>
-      {item.skuSpecifications.map((spec: SKUSpecification, idx: number) => {
+      {item.skuSpecifications.map((spec: SKUSpecification) => {
         return (
           <div
-            id={`${idx}-${spec.fieldName}-specification`}
+            id={`${item.id}-${spec.fieldName}-specification`}
             key={`${spec.fieldName}-key`}
           >
             {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}

--- a/react/ProductVariations.tsx
+++ b/react/ProductVariations.tsx
@@ -12,7 +12,7 @@ const ProductVariations: FunctionComponent = () => {
         return (
           <div
             id={`${item.id}-${spec.fieldName}-specification`}
-            key={`${spec.fieldName}-key`}
+            key={spec.fieldName}
           >
             {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
           </div>

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -14,6 +14,7 @@ const QuantitySelector: FunctionComponent = () => {
 
   return (
     <div
+      id={`${item.id}-selector`}
       className={`${opaque(item.availability)} ${styles.quantity} ${
         styles.quantitySelector
       }`}

--- a/react/RemoveButton.tsx
+++ b/react/RemoveButton.tsx
@@ -10,6 +10,7 @@ const RemoveButton: FunctionComponent = () => {
   return (
     <div className={opaque(item.availability)}>
       <button
+        id="remove-button"
         className="pointer bg-transparent bn pa2 ml6"
         title="remove"
         onClick={onRemove}


### PR DESCRIPTION
#### What problem is this solving?

In order to do the e2e tests, the elements need to have an identifier. This PR does it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://testid--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24034/adicionar-atributo-testid-em-elementos-da-ui)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

