### PR TITLE
Add "Remove" text to option 0 in quantity selector dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- "Remove" label to option zero in the quantity selector dropdown.
+
 ## [0.11.2] - 2019-10-18
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,5 +5,6 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# unavailable item} other {# unavailable items}}",
   "store/product-list.message.cantBeDelivered": "This item cannot be delivered to this address.",
   "store/product-list.message.noLongerAvailable": "This item is no longer available.",
-  "store/product-list.message.remove": "remove"
+  "store/product-list.message.remove": "remove",
+  "store/product-list.quantity-selector.remove": "Remove"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,5 +5,6 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# ítem no disponible} other {# ítems no disponibles}}",
   "store/product-list.message.cantBeDelivered": "Este item no se puede entregar a esta dirección.",
   "store/product-list.message.noLongerAvailable": "Este item no está disponible actualmente.",
-  "store/product-list.message.remove": "retirar"
+  "store/product-list.message.remove": "retirar",
+  "store/product-list.quantity-selector.remove": "Retirar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,5 +5,6 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# item indisponível} other {# itens indisponíveis}}",
   "store/product-list.message.cantBeDelivered": "Este item não pode ser entregue neste endereço.",
   "store/product-list.message.noLongerAvailable": "Este item não está mais disponível.",
-  "store/product-list.message.remove": "remover"
+  "store/product-list.message.remove": "remover",
+  "store/product-list.quantity-selector.remove": "Remover"
 }

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -1,6 +1,19 @@
 import { range } from 'ramda'
 import React, { FunctionComponent, useState } from 'react'
+import {
+  defineMessages,
+  InjectedIntl,
+  InjectedIntlProps,
+  injectIntl,
+} from 'react-intl'
 import { Dropdown, Input } from 'vtex.styleguide'
+
+const messages = defineMessages({
+  remove: {
+    defaultMessage: '',
+    id: 'store/product-list.quantity-selector.remove',
+  },
+})
 
 const MAX_INPUT_LENGTH = 5
 
@@ -39,10 +52,10 @@ const validateDisplayValue = (value: string, maxValue: number) => {
   return `${normalizeValue(parsedValue, maxValue)}`
 }
 
-const getDropdownOptions = (maxValue: number) => {
+const getDropdownOptions = (maxValue: number, intl: InjectedIntl) => {
   const limit = Math.min(9, maxValue)
   const options = [
-    { value: 0, label: '0' },
+    { value: 0, label: `0 - ${intl.formatMessage(messages.remove)}` },
     ...range(1, limit + 1).map(idx => ({ value: idx, label: `${idx}` })),
   ]
 
@@ -53,11 +66,12 @@ const getDropdownOptions = (maxValue: number) => {
   return options
 }
 
-const QuantitySelector: FunctionComponent<Props> = ({
+const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
   value,
   maxValue,
   onChange,
   disabled,
+  intl,
 }) => {
   const [curSelector, setSelector] = useState(
     value < 10 ? SelectorType.Dropdown : SelectorType.Input
@@ -109,7 +123,7 @@ const QuantitySelector: FunctionComponent<Props> = ({
   }
 
   if (curSelector === SelectorType.Dropdown) {
-    const dropdownOptions = getDropdownOptions(maxValue)
+    const dropdownOptions = getDropdownOptions(maxValue, intl)
 
     return (
       <div>
@@ -165,4 +179,4 @@ const QuantitySelector: FunctionComponent<Props> = ({
   }
 }
 
-export default QuantitySelector
+export default injectIntl(QuantitySelector)


### PR DESCRIPTION
#### What problem is this solving?

As the title says.

#### How should this be manually tested?

Add [some item](https://remove--vtexgame1.myvtex.com/teste-so-delivery-copy-256--copy-257--copy-261--copy-262-/p) to your cart, then to go `/cart`. Click the dropdown and verify the label for value zero is "0 - Remove".

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/24838/mostrar-texto-remover-na-opção-zero-do-dropdown-do-seletor-de-quantidade).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/67339976-ac3e1400-f502-11e9-8b63-8f1fa1f7967d.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
