### PR TITLE
Add item's identifier to remove button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Every remove button `id` has item's identifier now.
+
 ## [0.11.4] - 2019-10-23
 
 ### Changed

--- a/react/RemoveButton.tsx
+++ b/react/RemoveButton.tsx
@@ -10,7 +10,7 @@ const RemoveButton: FunctionComponent = () => {
   return (
     <div className={opaque(item.availability)}>
       <button
-        id="remove-button"
+        id={`remove-button-${item.id}`}
         className="pointer bg-transparent bn pa2 ml6"
         title="remove"
         onClick={onRemove}


### PR DESCRIPTION
#### What problem is this solving?

As the title says, this PR adds item's identifier to its remove button.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://cartske--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24797/ajustes-nos-ids-de-elementos-do-cart)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
