### PR TITLE
Add testId prop to Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `testId` prop to `Dropdown` component in order to allow the proper tests.
+
 ## [0.11.5] - 2019-10-23
 
 ### Changed

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -132,6 +132,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
         <div className="dn-m">
           <Dropdown
             id={`quantity-dropdown-mobile-${id}`}
+            testId={`quantity-dropdown-mobile-${id}`}
             options={dropdownOptions}
             size="small"
             value={normalizedValue}
@@ -143,6 +144,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
         <div className="dn db-m">
           <Dropdown
             id={`quantity-dropdown-${id}`}
+            testId={`quantity-dropdown-${id}`}
             options={dropdownOptions}
             value={normalizedValue}
             onChange={(event: any) => handleDropdownChange(event.target.value)}


### PR DESCRIPTION
#### What problem is this solving?

Currently, the `id` property is not being attached to the proper `Dropdown` inner element. So, the `testId` prop will be used as a value for `data-testId` attribute on the parent element inside `Dropdown` component. This will allow us to test `product-list` properly.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://cartske--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24797/ajustes-nos-ids-de-elementos-do-cart)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
