### PR TITLE
Display higher resolution images depending on the user device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Images with higher resolutions are now displayed if the user device has retina screen.
+
 ## [0.12.0] - 2019-10-30
 
 ### Added

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -5,6 +5,23 @@ import { NoImageIcon } from './components/NoImageIcon'
 import { opaque } from './utils/opaque'
 import { Loading } from 'vtex.render-runtime'
 
+const getImageUrl = (imageUrls: Item['imageUrls']) => {
+  if (!imageUrls) {
+    return null
+  }
+  if (!window || !window.devicePixelRatio) {
+    return imageUrls.at1x
+  }
+
+  if (window.devicePixelRatio <= 1.25) {
+    return imageUrls.at1x
+  } else if (window.devicePixelRatio <= 2.25) {
+    return imageUrls.at2x
+  } else {
+    return imageUrls.at3x
+  }
+}
+
 const Image: FunctionComponent = () => {
   const { item, loading } = useItemContext()
 
@@ -12,20 +29,17 @@ const Image: FunctionComponent = () => {
     return <Loading />
   }
 
+  const imageUrl = getImageUrl(item.imageUrls)
+
   return (
     <div
       id={`image-${item.id}`}
       className={opaque(item.availability)}
-      style={{ minWidth: '96px' }}
+      style={{ width: '96px' }}
     >
       <a href={item.detailUrl}>
-        {item.imageUrl ? (
-          <img
-            className="br2"
-            alt={item.name}
-            src={item.imageUrl}
-            width="100%"
-          />
+        {imageUrl ? (
+          <img className="br2" alt={item.name} src={imageUrl} width="100%" />
         ) : (
           <NoImageIcon />
         )}

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -11,7 +11,11 @@ declare global {
     availability: string
     detailUrl: string
     id: string
-    imageUrl: string | null
+    imageUrls?: {
+      at1x: string
+      at2x: string
+      at3x: string
+    }
     listPrice: number
     measurementUnit: string
     name: string


### PR DESCRIPTION
#### What problem is this solving?

This makes the component display images with higher resolution if the user's screen has a high pixel density (retina displays).

#### How should this be manually tested?

[Go to cart](https://retina--checkoutio.myvtex.com/cart/add?sku=33) and check the URL of the image of the product. On 3x displays, the image URL should end with `288-auto`. On 2x displays, it should end with `192-auto` and on screens, it should end with `96-auto`.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/21675/implementar-imagens-otimizadas-para-telas-retina).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
