### PR TITLE
Update `image` interface name to `product-list-image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `image` interface name to `product-list-image`.
+
 ## [0.13.0] - 2019-11-01
 
 ### Changed

--- a/store/blocks/desktop.json
+++ b/store/blocks/desktop.json
@@ -16,7 +16,7 @@
     }
   },
   "flex-layout.col#image.desktop": {
-    "children": ["image"],
+    "children": ["product-list-image"],
     "props": {
       "marginRight": "6"
     }

--- a/store/blocks/mobile.json
+++ b/store/blocks/mobile.json
@@ -16,7 +16,7 @@
     }
   },
   "flex-layout.col#image.mobile": {
-    "children": ["image"],
+    "children": ["product-list-image"],
     "props": {
       "marginRight": "5"
     }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -13,7 +13,7 @@
     "composition": "children",
     "allowed": "*"
   },
-  "image": {
+  "product-list-image": {
     "component": "Image",
     "preview": {
       "type": "box",


### PR DESCRIPTION
#### What problem is this solving?

Renaming the interface avoids conflict with the existing `image` interface exported by `store-components`.

#### How should this be manually tested?

This workspace is using the new minicart (spoilers ahead). Add an item to the cart and check that the image still appears in the `product-list` being used inside of the `minicart`.

[Workspace](https://minicart3x--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
✔️ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

In theory, this is a breaking change, but I this block appears to only be used inside this app, so it should not break anything :)
