### PR TITLE
Adapts store interfaces to the new render-runtime preview structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `interfaces` preview structure.
+
 ## [0.13.1] - 2019-11-05
 
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -19,7 +19,10 @@
       "type": "box",
       "height": 96,
       "width": 96,
-      "minWidth": 96
+      "options": {
+        "padding": 0,
+        "minWidth": 96
+      }
     }
   },
   "message": {
@@ -30,7 +33,10 @@
     "preview": {
       "type": "box",
       "height": 30,
-      "width": 260
+      "width": 260,
+      "options": {
+        "padding": 0
+      }
     }
   },
   "product-brand": {
@@ -38,7 +44,10 @@
     "preview": {
       "type": "box",
       "height": 15,
-      "width": 120
+      "width": 120,
+      "options": {
+        "padding": 0
+      }
     }
   },
   "product-variations": {
@@ -49,7 +58,10 @@
     "preview": {
       "type": "box",
       "height": 35,
-      "width": 90
+      "width": 90,
+      "options": {
+        "padding": 0
+      }
     }
   },
   "unit-price": {
@@ -60,7 +72,10 @@
     "preview": {
       "type": "box",
       "height": 35,
-      "width": 100
+      "width": 100,
+      "options": {
+        "padding": 0
+      }
     }
   },
   "remove-button": {
@@ -68,7 +83,10 @@
     "preview": {
       "type": "box",
       "height": 25,
-      "width": 25
+      "width": 25,
+      "options": {
+        "padding": 0
+      }
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

As the title says, this PR intends to adapt the store `interfaces` to the new render-runtime preview.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://productskeleton--checkoutio.myvtex.com/cart)
- Compare with the screenshots below

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24408/aplicar-o-skeleton-no-carregamento-do-carrinho)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/68500454-86bb4500-023a-11ea-8e45-e20317471b4d.png)


#### Type of changes

<!--- Add a ✔️where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

