### PR TITLE
Add extra item argument to update handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New `item` argument to callback functions `onQuantityChange` and `onRemove` passed to `ProductList` component.
+
 ## [0.13.2] - 2019-11-08
 
 ### Changed

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -7,8 +7,8 @@ import { AVAILABLE } from './constants/Availability'
 interface Props {
   items: Item[]
   loading: boolean
-  onQuantityChange: (uniqueId: string, value: number) => void
-  onRemove: (uniqueId: string) => void
+  onQuantityChange: (uniqueId: string, value: number, item?: Item) => void
+  onRemove: (uniqueId: string, item?: Item) => void
 }
 
 const ProductList: StorefrontFunctionComponent<Props> = ({
@@ -34,8 +34,8 @@ const ProductList: StorefrontFunctionComponent<Props> = ({
           item,
           loading,
           onQuantityChange: (value: number) =>
-            onQuantityChange(item.uniqueId, value),
-          onRemove: () => onRemove(item.uniqueId),
+            onQuantityChange(item.uniqueId, value, item),
+          onRemove: () => onRemove(item.uniqueId, item),
         }}
       >
         <div className="c-on-base bb b--muted-4">{children}</div>

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -21,6 +21,9 @@ declare global {
     name: string
     price: number
     productId: string
+    productCategories: Record<string, string>
+    productCategoryIds: string
+    productRefId: string
     quantity: number
     sellingPrice: number
     skuName: string


### PR DESCRIPTION
#### What problem is this solving?

Add a new `item` argument to callback functions `onQuantityChange` and `onRemove` passed to `ProductList` component.

This enables another component that is using `<ProductList />` to have access to the item being modified. That is especially useful for sending events to `pixel-manager`.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
