### PR TITLE
Adjusts preview width values to keep the expected behavior on mobile …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Component's preview width values, in order to keep the expected behavior on mobile devices.
+
 ## [0.14.1] - 2019-11-21
 
 ### Changed

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -33,7 +33,7 @@
     "preview": {
       "type": "box",
       "height": 30,
-      "width": 260,
+      "width": 140,
       "options": {
         "padding": 0
       }
@@ -44,7 +44,7 @@
     "preview": {
       "type": "box",
       "height": 15,
-      "width": 120,
+      "width": 110,
       "options": {
         "padding": 0
       }
@@ -58,7 +58,7 @@
     "preview": {
       "type": "box",
       "height": 35,
-      "width": 90,
+      "width": 80,
       "options": {
         "padding": 0
       }
@@ -72,7 +72,7 @@
     "preview": {
       "type": "box",
       "height": 35,
-      "width": 100,
+      "width": 90,
       "options": {
         "padding": 0
       }


### PR DESCRIPTION
…devices

#### What problem is this solving?

The `product-list` skeleton preview wasn't behaving properly on mobile devices. This PR fix it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixskeleton--checkoutio.myvtex.com/cart)
- Change the visualization to the mobile device mode
- Reload the page
- Verify that `product-list` isn't taking a width bigger than the device's one.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/26848/corrigir-skeleton-mobile)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️| Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
