### PR TITLE
Fix skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Skeleton appearance was delayed.
+
 ## [0.14.2] - 2019-11-21
 
 ### Changed

--- a/react/ProductListWrapper.tsx
+++ b/react/ProductListWrapper.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 const ProductListWrapper: StorefrontFunctionComponent<Props> = props => {
   return (
-    <SizeMe>
+    <SizeMe noPlaceholder={true}>
       {({ size }) =>
         size.width && size.width < MAX_MOBILE_WIDTH ? (
           <ExtensionPoint id="product-list-content-mobile" {...props} />


### PR DESCRIPTION
#### What problem is this solving?

The ProductList skeleton was not showing up at the same time as the Summary one because of the `SizeMe` component, which waits for the inner component to load before showing it on screen.

I've added a `noPlaceholder` prop to `SizeMe` and now both skeletons appear at the same time. However, a previously existing issue now becomes more noticeable: On mobile screens, the page first loads the desktop skeleton, then loads the mobile one. This should be further investigated.

#### How should this be manually tested?

[Workspace](https://skeleton--checkoutio.myvtex.com/cart/add?sku=291&sku=256&sku=287&sku=308&sku=288&sku=306&sku=330&sku=36&sku=269&sku=321)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/26180/melhorar-loading-com-skeleton)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
