### PR TITLE
Force mobile skeleton on phone devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Desktop skeleton appearing on phone screens.
+
 ## [0.14.3] - 2019-11-25
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,9 @@
     "vtex.styleguide": "9.x",
     "vtex.format-currency": "0.x",
     "vtex.formatted-price": "0.x",
-    "vtex.flex-layout": "0.x"
+    "vtex.flex-layout": "0.x",
+    "vtex.device-detector": "0.x",
+    "vtex.order-manager": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/ProductListWrapper.tsx
+++ b/react/ProductListWrapper.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { SizeMe } from 'react-sizeme'
+import { useDevice } from 'vtex.device-detector'
+import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 const MAX_MOBILE_WIDTH = 640
 
@@ -11,10 +13,14 @@ interface Props {
 }
 
 const ProductListWrapper: StorefrontFunctionComponent<Props> = props => {
+  const { loading } = useOrderForm()
+  const { device } = useDevice()
+
   return (
     <SizeMe noPlaceholder={true}>
       {({ size }) =>
-        size.width && size.width < MAX_MOBILE_WIDTH ? (
+        (loading && device === 'phone') ||
+        (size.width && size.width < MAX_MOBILE_WIDTH) ? (
           <ExtensionPoint id="product-list-content-mobile" {...props} />
         ) : (
           <ExtensionPoint id="product-list-content-desktop" {...props} />


### PR DESCRIPTION
#### What problem is this solving?

To determine which layout (mobile or desktop) we display for the Product List we use the width of the container the Product List is in. However, when the page is loading this information is not initially available, so the component defaults to the desktop layout and stuff like this happens:

<img src="https://user-images.githubusercontent.com/8902498/69730346-a1c8f880-1106-11ea-978e-68821f1f3fdb.png"  height="500px"/>

This PR tries to mitigate this by using the device type as a fallback condition to determine which layout to display. If it is a phone device, it shows the mobile layout. However, this fix doesn't apply to the vertical tablet case so this still happens:

| loading | ![image](https://user-images.githubusercontent.com/8902498/69743971-18252500-111e-11ea-9dd3-9b2f0a69fa38.png)|
|----------|---------------|
| finished loading |![image](https://user-images.githubusercontent.com/8902498/69743892-f62ba280-111d-11ea-9b7d-57f6a0668616.png)|
----------------------

I don't think this case is as critical as the mobile one, though, so we can come up with a solution for that case in a future PR.

#### How should this be manually tested?

[Workspace](https://skeleton--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/27174/corrigir-skeleton-desktop-mostrando-no-mobile).
- [ ] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
| before | after |
|--------|------|
|![image](https://user-images.githubusercontent.com/8902498/69750788-5c1f2680-112c-11ea-9a12-7eeb927630fe.png) | ![image](https://user-images.githubusercontent.com/8902498/69750763-47429300-112c-11ea-83d1-2b892c4cf761.png) |

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
