### PR TITLE
Rename blocks to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Interface names to avoid collisions with interfaces defined in other apps.
+
 ## [0.14.4] - 2019-12-03
 
 ### Fixed

--- a/store/blocks/common.json
+++ b/store/blocks/common.json
@@ -12,16 +12,16 @@
     }
   },
   "flex-layout.row#product-brand": {
-    "children": ["product-brand"],
+    "children": ["product-list-product-brand"],
     "props": {
       "marginBottom": "2"
     }
   },
   "flex-layout.row#product-name": {
-    "children": ["product-name"]
+    "children": ["product-list-product-name"]
   },
   "flex-layout.row#product-variations": {
-    "children": ["product-variations"],
+    "children": ["product-list-product-variations"],
     "props": {
       "marginTop": "2"
     }

--- a/store/blocks/desktop.json
+++ b/store/blocks/desktop.json
@@ -60,25 +60,25 @@
     }
   },
   "flex-layout.row#quantity-selector.desktop": {
-    "children": ["quantity-selector"],
+    "children": ["product-list-quantity-selector"],
     "props": {
       "preventHorizontalStretch": "true"
     }
   },
   "flex-layout.row#unit-price.desktop": {
-    "children": ["unit-price#desktop"],
+    "children": ["product-list-unit-price#desktop"],
     "props": {
       "marginTop": "3",
       "preventHorizontalStretch": "true"
     }
   },
-  "unit-price#desktop": {
+  "product-list-unit-price#desktop": {
     "props": {
       "textAlign": "center"
     }
   },
   "flex-layout.col#price.desktop": {
-    "children": ["price#desktop"],
+    "children": ["product-list-price#desktop"],
     "props": {
       "blockClass": "priceWrapper",
       "marginLeft": "6",
@@ -86,25 +86,25 @@
       "verticalAlign": "middle"
     }
   },
-  "price#desktop": {
+  "product-list-price#desktop": {
     "props": {
       "textAlign": "right"
     }
   },
   "flex-layout.col#remove-button.desktop": {
-    "children": ["remove-button"],
+    "children": ["product-list-remove-button"],
     "props": {
       "marginLeft": "6",
       "verticalAlign": "middle"
     }
   },
   "flex-layout.row#message.desktop": {
-    "children": ["message#desktop"],
+    "children": ["product-list-message#desktop"],
     "props": {
       "marginTop": "4"
     }
   },
-  "message#desktop": {
+  "product-list-message#desktop": {
     "props": {
       "layout": "cols"
     }

--- a/store/blocks/mobile.json
+++ b/store/blocks/mobile.json
@@ -44,43 +44,43 @@
     }
   },
   "flex-layout.row#quantity-selector.mobile": {
-    "children": ["quantity-selector"],
+    "children": ["product-list-quantity-selector"],
     "props": {
       "marginTop": "5",
       "preventHorizontalStretch": "true"
     }
   },
   "flex-layout.row#unit-price.mobile": {
-    "children": ["unit-price"],
+    "children": ["product-list-unit-price"],
     "props": {
       "marginTop": "3"
     }
   },
   "flex-layout.row#price.mobile": {
-    "children": ["price#mobile"],
+    "children": ["product-list-price#mobile"],
     "props": {
       "marginTop": "5",
       "preventHorizontalStretch": "true"
     }
   },
-  "price#mobile": {
+  "product-list-price#mobile": {
     "props": {
       "textAlign": "left"
     }
   },
   "flex-layout.col#remove-button.mobile": {
-    "children": ["remove-button"],
+    "children": ["product-list-remove-button"],
     "props": {
       "marginLeft": "3"
     }
   },
   "flex-layout.row#message.mobile": {
-    "children": ["message#mobile"],
+    "children": ["product-list-message#mobile"],
     "props": {
       "marginTop": "3"
     }
   },
-  "message#mobile": {
+  "product-list-message#mobile": {
     "props": {
       "layout": "rows"
     }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -25,10 +25,10 @@
       }
     }
   },
-  "message": {
+  "product-list-message": {
     "component": "AvailabilityMessage"
   },
-  "product-name": {
+  "product-list-product-name": {
     "component": "ProductName",
     "preview": {
       "type": "box",
@@ -39,7 +39,7 @@
       }
     }
   },
-  "product-brand": {
+  "product-list-product-brand": {
     "component": "ProductBrand",
     "preview": {
       "type": "box",
@@ -50,10 +50,10 @@
       }
     }
   },
-  "product-variations": {
+  "product-list-product-variations": {
     "component": "ProductVariations"
   },
-  "quantity-selector": {
+  "product-list-quantity-selector": {
     "component": "QuantitySelector",
     "preview": {
       "type": "box",
@@ -64,10 +64,10 @@
       }
     }
   },
-  "unit-price": {
+  "product-list-unit-price": {
     "component": "UnitPrice"
   },
-  "price": {
+  "product-list-price": {
     "component": "Price",
     "preview": {
       "type": "box",
@@ -78,7 +78,7 @@
       }
     }
   },
-  "remove-button": {
+  "product-list-remove-button": {
     "component": "RemoveButton",
     "preview": {
       "type": "box",


### PR DESCRIPTION
#### What problem is this solving?

Once the MiniCart with the components from our Cart was published, Boticario started having problems when linking their app because both `vtex.product-list` and `vtex.store-components` define the interface `product-name`. This PR prepends the name of the app (`product-list`) to the interfaces this app defines to reduce the chances of collisions.

#### How should this be manually tested?

[Workspace](https://blocks--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17). The product list should work with no issues.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/27427/renomear-blocos-do-checkout-io).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
