### PR TITLE
Remove "remove" button from availability message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+- "Remove" button from availability message.
+
 ## [0.14.5] - 2019-12-18
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,6 +5,5 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# unavailable item} other {# unavailable items}}",
   "store/product-list.message.cantBeDelivered": "This item cannot be delivered to this address.",
   "store/product-list.message.noLongerAvailable": "This item is no longer available.",
-  "store/product-list.message.remove": "remove",
   "store/product-list.quantity-selector.remove": "Remove"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,6 +5,5 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# ítem no disponible} other {# ítems no disponibles}}",
   "store/product-list.message.cantBeDelivered": "Este item no se puede entregar a esta dirección.",
   "store/product-list.message.noLongerAvailable": "Este item no está disponible actualmente.",
-  "store/product-list.message.remove": "retirar",
   "store/product-list.quantity-selector.remove": "Retirar"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,6 +5,5 @@
   "store/product-list.unavailableItems": "{quantity, plural, one {# item indisponível} other {# itens indisponíveis}}",
   "store/product-list.message.cantBeDelivered": "Este item não pode ser entregue neste endereço.",
   "store/product-list.message.noLongerAvailable": "Este item não está mais disponível.",
-  "store/product-list.message.remove": "remover",
   "store/product-list.quantity-selector.remove": "Remover"
 }

--- a/react/AvailabilityMessage.tsx
+++ b/react/AvailabilityMessage.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
-import { Button } from 'vtex.styleguide'
 
 import { useItemContext } from './components/ItemContext'
 import { AVAILABLE, CANNOT_BE_DELIVERED } from './constants/Availability'
@@ -20,24 +19,12 @@ const setContainerLayout = (prop: string) => {
   }
 }
 
-const setTextLayout = (prop: string) => {
-  switch (prop) {
-    case 'cols':
-      return 'pa4'
-    case 'rows':
-      return 'pt4 pr4 pb0 pl4'
-    default:
-      return ''
-  }
-}
-
 const AvailabilityMessage: StorefrontFunctionComponent<Props> = ({
   layout,
 }) => {
   const {
     item: { availability },
     loading,
-    onRemove,
   } = useItemContext()
 
   if (loading) {
@@ -46,22 +33,12 @@ const AvailabilityMessage: StorefrontFunctionComponent<Props> = ({
 
   return availability !== AVAILABLE ? (
     <div className={`bg-warning--faded br2 ${setContainerLayout(layout)}`}>
-      <div className={`t-small lh-title ${setTextLayout(layout)}`}>
+      <div className="lh-title pa4">
         {availability === CANNOT_BE_DELIVERED ? (
           <FormattedMessage id="store/product-list.message.cantBeDelivered" />
         ) : (
           <FormattedMessage id="store/product-list.message.noLongerAvailable" />
         )}
-      </div>
-      <div className="ph3">
-        <Button
-          id="availability-remove-button"
-          variation="tertiary"
-          onClick={onRemove}
-          collapseRight
-        >
-          <FormattedMessage id="store/product-list.message.remove" />
-        </Button>
       </div>
     </div>
   ) : null

--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.14.5"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5942,10 +5942,10 @@ typed-styles@^0.0.7:
   resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.7.tgz#93392a008794c4595119ff62dde6809dbc40a3d9"
   integrity sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.4.3"


### PR DESCRIPTION
#### What problem is this solving?

When an item is unavailable, the product list would display an message below the item with a "Remove" button. This button could cause confusion because it is not clear what that button would remove (the message itself or the item). This PR removes this button and changes the message font size to 16px, as requested by @davicosta99.

#### How should this be manually tested?

Use [this workspace](https://remove--checkoutio.myvtex.com/cart/add?sku=31&sku=33&sku=250) and use 04538-132 as the ZIP code. Test both desktop and mobile layouts.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/28349/eu-como-comprador-não-quero-ter-dúvida-sobre-o-remover-no-alerta-do-produto-que-não-pode-ser-entregue).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/71199420-b1a2ab00-2274-11ea-8d9a-2b2cb5709886.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
