### PR TITLE
Replace Fragment by div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Product list layout.
+
 ## [0.15.1] - 2019-12-23
 
 ### Changed

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -54,7 +54,9 @@ const ProductList: StorefrontFunctionComponent<Props> = ({
     ))
 
   return (
-    <Fragment>
+    /* Replacing the outer div by a Fragment may break the layout. See PR #39. */
+
+    <div>
       {unavailableItems.length > 0 ? (
         <div
           id="unavailable-items"
@@ -78,7 +80,7 @@ const ProductList: StorefrontFunctionComponent<Props> = ({
         </div>
       ) : null}
       {productList(availableItems)}
-    </Fragment>
+    </div>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?

Changing `div` to `Fragment` in the last PR broke the layout of the Product List because this component is wrapped by a `flex-layout` container in the Checkout Cart, causing all items to be displayed in a single row. This PR changes it back to `div`.

#### How should this be manually tested?

The **product list** of [this workspace](https://div--checkoutio.myvtex.com/cart/add?sku=31&sku=33&sku=250) should not have a broken layout.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
