### PR TITLE
Update logic for rendering mobile or desktop product-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Logic concerning the rendering of `product-list-content-desktop` and `product-list-content-mobile`.
 
 ## [0.15.4] - 2019-12-30
 ### Changed

--- a/react/ProductListWrapper.tsx
+++ b/react/ProductListWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { SizeMe } from 'react-sizeme'
 import { Item } from 'vtex.checkout-graphql'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { ExtensionPoint, useChildBlock } from 'vtex.render-runtime'
 import { useDevice } from 'vtex.device-detector'
 import { OrderForm } from 'vtex.order-manager'
 
@@ -18,6 +18,19 @@ interface Props {
 const ProductListWrapper: StorefrontFunctionComponent<Props> = props => {
   const { loading } = useOrderForm()
   const { device } = useDevice()
+  const hasMobileContent = Boolean(
+    useChildBlock({ id: 'product-list-content-mobile' })
+  )
+  const hasDesktopContent = Boolean(
+    useChildBlock({ id: 'product-list-content-desktop' })
+  )
+
+  if (!hasMobileContent) {
+    return <ExtensionPoint id="product-list-content-desktop" {...props} />
+  }
+  if (!hasDesktopContent) {
+    return <ExtensionPoint id="product-list-content-mobile" {...props} />
+  }
 
   return (
     <SizeMe noPlaceholder>


### PR DESCRIPTION
#### What problem is this solving?

It enables the user to always use a certain version of `product-list` (mobile or desktop).

This is especially useful for the minicart, since we always want it to use the mobile variant of `product-list-content`.

#### How should this be manually tested?

This is a workspace with this version linked:
[Workspace](https://minicartchildren--storecomponents.myvtex.com/)

This is the [master workspace](https://storecomponents.myvtex.com/). Notice how the product-list is weird the first time it is rendered since the desktop version is being rendered. This happens because during SSR `size.width` variable in:

```tsx
return (
    <SizeMe noPlaceholder>
      {({ size }) =>
        (loading && device === 'phone') ||
        (size.width && size.width < MAX_MOBILE_WIDTH) ? (
          <ExtensionPoint id="product-list-content-mobile" {...props} />
        ) : (
          <ExtensionPoint id="product-list-content-desktop" {...props} />
        )
      }
    </SizeMe>
  )
```

is `null`, so `product-list-content-desktop` ends up being rendered.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and an overall reduction of technical debt -->
