### PR TITLE
Add advanced blocks configuration section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- ### Added
+### Added
 - `Advanced configuration` section in the documentation.
 
 ## [0.16.0] - 2020-01-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- ### Added
+- `Advanced configuration` section in the documentation.
 
 ## [0.16.0] - 2020-01-28
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,44 +22,11 @@ The Product List displays all items in the user's cart and informs the user when
   }
 ```
 
-## Customization
+### Advanced Configuration
 
-In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
+The `product-list` block is made up of other smalled blocks. Currently, its default implementation is as follows (props omited):
 
-| CSS Handles                          |
-| ------------------------------------ |
-| `availabilityMessageContainer`       |
-| `availabilityMessageTextContainer`   |
-| `availabilityMessageText`            |
-| `productImageContainer`              |
-| `productImageAnchor`                 |
-| `productImage`                       |
-| `productPriceContainer`              |
-| `productPriceCurrency`               |
-| `productPrice`                       |
-| `productBrandName`                   |
-| `productListItem`                    |
-| `productListUnavailableItemsMessage` |
-| `productListAvailableItemsMessage`   |
-| `productName`                        |
-| `productVariationsContainer`         |
-| `productVariationsItem`              |
-| `quantitySelectorContainer`          |
-| `removeButtonContainer`              |
-| `removeButton`                       |
-| `unitPriceContainer`                 |
-| `unitPricePerUnitCurrency`           |
-| `unitPriceMeasurementUnit`           |
-| `quantityDropdownMobileContainer`    |
-| `quantityDropdownContainer`          |
-| `quantityInputMobileContainer`       |
-| `quantityInputContainer`             |
-
-## Advanced Configuration
-
-The `product-list` block can be customized through its blocks structure. The default implementation is currently the following (props were omited):
-
-```jsonc
+```json
 {
   "product-list": {
     "blocks": [
@@ -89,11 +56,10 @@ The `product-list` block can be customized through its blocks structure. The def
 }
 ```
 
-### Desktop layout
+#### Desktop layout
 
-```jsonc
+```json
 {
-  // Desktop layout
   "product-list-content-desktop": {
     "children": ["flex-layout.row#list-row.desktop"]
   },
@@ -169,11 +135,10 @@ The `product-list` block can be customized through its blocks structure. The def
 }
 ```
 
-### Mobile layout
+#### Mobile layout
 
-```jsonc
+```json
 {
-  // Mobile layout (this is default one used by minicart.v2)
   "product-list-content-mobile": {
     "children": ["flex-layout.row#list-row.mobile"]
   },
@@ -234,4 +199,39 @@ The `product-list` block can be customized through its blocks structure. The def
 }
 ```
 
-This means that, when you use `product-list` in your store, you're actually using this default implementation. So, to customize the blocks being used in your own implementation, you could get this default and change it as you like by adding this blocks to your theme and changing their configuration. Just keep in mind that the blocks above will be added into your theme regardless, so you could use them the way you like.
+By default implementation we mean that whenever you use `product-list` in your store you're actually using the `json` above behind the scenes.
+
+Therefore, in order to customize the Product List configuration, you can simply use the default implementation in your code and change it as you wish.
+
+## Customization
+
+In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
+
+| CSS Handles                          |
+| ------------------------------------ |
+| `availabilityMessageContainer`       |
+| `availabilityMessageTextContainer`   |
+| `availabilityMessageText`            |
+| `productBrandName`                   |
+| `productImageAnchor`                 |
+| `productImageContainer`              |
+| `productImage`                       |
+| `productListAvailableItemsMessage`   |
+| `productListItem`                    |
+| `productListUnavailableItemsMessage` |
+| `productName`                        |
+| `productPriceContainer`              |
+| `productPriceCurrency`               |
+| `productPrice`                       |
+| `productVariationsContainer`         |
+| `productVariationsItem`              |
+| `quantityDropdownContainer`          |
+| `quantityDropdownMobileContainer`    |
+| `quantityInputContainer`             |
+| `quantityInputMobileContainer`       |
+| `quantitySelectorContainer`          |
+| `removeButtonContainer`              |
+| `removeButton`                       |
+| `unitPriceContainer`                 |
+| `unitPriceMeasurementUnit`           |
+| `unitPricePerUnitCurrency`           |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ The Product List displays all items in the user's cart and informs the user when
 
 ### Advanced Configuration
 
-The `product-list` block is made up of other smalled blocks. Currently, its default implementation is as follows (props omited):
+The `product-list` block is made up of other smaller blocks. Currently, its default implementation is as follows (props omitted):
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,3 +54,184 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `quantityDropdownContainer`          |
 | `quantityInputMobileContainer`       |
 | `quantityInputContainer`             |
+
+## Advanced Configuration
+
+The `product-list` block can be customized through its blocks structure. The default implementation is currently the following (props were omited):
+
+```jsonc
+{
+  "product-list": {
+    "blocks": [
+      "product-list-content-desktop",
+      "product-list-content-mobile"
+    ]
+  },
+  "flex-layout.col#product-description": {
+    "children": [
+      "flex-layout.row#product-brand",
+      "flex-layout.row#product-name",
+      "flex-layout.row#product-variations"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#product-brand": {
+    "children": ["product-brand"],
+    "props": { (...) }
+  },
+  "flex-layout.row#product-name": {
+    "children": ["product-name"]
+  },
+  "flex-layout.row#product-variations": {
+    "children": ["product-variations"],
+    "props": { (...) }
+  }
+}
+```
+
+### Desktop layout
+
+```jsonc
+{
+  // Desktop layout
+  "product-list-content-desktop": {
+    "children": ["flex-layout.row#list-row.desktop"]
+  },
+  "flex-layout.row#list-row.desktop": {
+    "children": [
+      "flex-layout.col#image.desktop",
+      "flex-layout.col#main-container.desktop"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.col#image.desktop": {
+    "children": ["product-list-image"],
+    "props": { (...) }
+  },
+  "flex-layout.col#main-container.desktop": {
+    "children": [
+      "flex-layout.row#sub-container.desktop",
+      "flex-layout.row#message.desktop"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#sub-container.desktop": {
+    "children": [
+      "flex-layout.col#product-description",
+      "flex-layout.col#quantity.desktop",
+      "flex-layout.row#price-remove"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.col#quantity.desktop": {
+    "children": [
+      "flex-layout.row#quantity-selector.desktop",
+      "flex-layout.row#unit-price.desktop"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#price-remove": {
+    "children": [
+      "flex-layout.col#price.desktop",
+      "flex-layout.col#remove-button.desktop"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#quantity-selector.desktop": {
+    "children": ["quantity-selector"],
+    "props": { (...) }
+  },
+  "flex-layout.row#unit-price.desktop": {
+    "children": ["unit-price#desktop"],
+    "props": { (...) }
+  },
+  "unit-price#desktop": {
+    "props": { (...) }
+  },
+  "flex-layout.col#price.desktop": {
+    "children": ["price#desktop"],
+    "props": { (...) }
+  },
+  "price#desktop": {
+    "props": { (...) }
+  },
+  "flex-layout.col#remove-button.desktop": {
+    "children": ["remove-button"],
+    "props": { (...) }
+  },
+  "flex-layout.row#message.desktop": {
+    "children": ["message#desktop"],
+    "props": { (...) }
+  },
+  "message#desktop": {
+    "props": { (...) }
+  }
+}
+```
+
+### Mobile layout
+
+```jsonc
+{
+  // Mobile layout (this is default one used by minicart.v2)
+  "product-list-content-mobile": {
+    "children": ["flex-layout.row#list-row.mobile"]
+  },
+  "flex-layout.row#list-row.mobile": {
+    "children": [
+      "flex-layout.col#image.mobile",
+      "flex-layout.col#main-container.mobile"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.col#image.mobile": {
+    "children": ["product-list-image"],
+    "props": { (...) }
+  },
+  "flex-layout.col#main-container.mobile": {
+    "children": [
+      "flex-layout.row#top.mobile",
+      "flex-layout.row#quantity-selector.mobile",
+      "flex-layout.row#unit-price.mobile",
+      "flex-layout.row#price.mobile",
+      "flex-layout.row#message.mobile"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#top.mobile": {
+    "children": [
+      "flex-layout.col#product-description",
+      "flex-layout.col#remove-button.mobile"
+    ],
+    "props": { (...) }
+  },
+  "flex-layout.row#quantity-selector.mobile": {
+    "children": ["quantity-selector"],
+    "props": { (...) }
+  },
+  "flex-layout.row#unit-price.mobile": {
+    "children": ["unit-price"],
+    "props": { (...) }
+  },
+  "flex-layout.row#price.mobile": {
+    "children": ["price#mobile"],
+    "props": { (...) }
+  },
+  "price#mobile": {
+    "props": { (...) }
+  },
+  "flex-layout.col#remove-button.mobile": {
+    "children": ["remove-button"],
+    "props": { (...) }
+  },
+  "flex-layout.row#message.mobile": {
+    "children": ["message#mobile"],
+    "props": { (...) }
+  },
+  "message#mobile": {
+    "props": { (...) }
+  }
+}
+```
+
+This means that, when you use `product-list` in your store, you're actually using this default implementation. So, to customize the blocks being used in your own implementation, you could get this default and change it as you like by adding this blocks to your theme and changing their configuration. Just keep in mind that the blocks above will be added into your theme regardless, so you could use them the way you like.


### PR DESCRIPTION
#### What problem is this solving?

This should help people to understand better how to customize the `product-list` block.

#### How should this be manually tested?

https://github.com/vtex-apps/product-list/tree/feature/advanced-docs/docs

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and the overall reduction of technical debt -->
