### PR TITLE
Add product quantity component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - New component `ProductQuantity`.
+- Prop `showListPrice` to `Price` component.
 
 ## [0.17.0] - 2020-01-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New component `ProductQuantity`.
 
 ## [0.17.0] - 2020-01-29
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,6 +223,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `productPriceContainer`              |
 | `productPriceCurrency`               |
 | `productPrice`                       |
+| `productQuantityUnit`                |
 | `productVariationsContainer`         |
 | `productVariationsItem`              |
 | `quantityDropdownContainer`          |

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,5 +6,6 @@
   "store/product-list.message.cantBeDelivered": "This product cannot be delivered to the address provided.",
   "store/product-list.message.noLongerAvailable": "This product is no longer available.",
   "store/product-list.message.remove": "remove",
-  "store/product-list.quantity-selector.remove": "Remove"
+  "store/product-list.quantity-selector.remove": "Remove",
+  "store/product-list.quantity-units": "{quantity} un."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,5 +6,6 @@
   "store/product-list.message.cantBeDelivered": "Este producto no se puede entregar en la dirección proporcionada.",
   "store/product-list.message.noLongerAvailable": "Este producto no está disponible actualmente.",
   "store/product-list.message.remove": "retirar",
-  "store/product-list.quantity-selector.remove": "Retirar"
+  "store/product-list.quantity-selector.remove": "Retirar",
+  "store/product-list.quantity-units": "{quantity} un."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,5 +6,6 @@
   "store/product-list.message.cantBeDelivered": "Este produto não pode ser entregue no endereço fornecido.",
   "store/product-list.message.noLongerAvailable": "Este produto não está mais disponível.",
   "store/product-list.message.remove": "remover",
-  "store/product-list.quantity-selector.remove": "Remover"
+  "store/product-list.quantity-selector.remove": "Remover",
+  "store/product-list.quantity-units": "{quantity} un."
 }

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -15,7 +15,14 @@ const CSS_HANDLES = [
   'productPrice',
 ] as const
 
-const Price: StorefrontFunctionComponent<TextAlignProp> = ({ textAlign }) => {
+type PriceProps = TextAlignProp & {
+  showListPrice: boolean
+}
+
+const Price: StorefrontFunctionComponent<PriceProps> = ({
+  textAlign = 'left',
+  showListPrice = true,
+}) => {
   const { item, loading } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -29,7 +36,7 @@ const Price: StorefrontFunctionComponent<TextAlignProp> = ({ textAlign }) => {
         handles.productPriceContainer
       } ${parseTextAlign(textAlign)}`}
     >
-      {item.listPrice !== item.price && (
+      {item.listPrice !== item.price && showListPrice && (
         <div
           id={`list-price-${item.id}`}
           className={`${handles.productPriceCurrency} c-muted-1 strike t-mini mb2`}
@@ -47,15 +54,11 @@ const Price: StorefrontFunctionComponent<TextAlignProp> = ({ textAlign }) => {
   )
 }
 
-Price.defaultProps = {
-  textAlign: 'left',
-}
-
 Price.schema = {
   properties: {
     textAlign: {
       type: 'string',
-      default: Price.defaultProps.textAlign,
+      default: 'left',
       isLayout: true,
     },
   },

--- a/react/ProductQuantity.tsx
+++ b/react/ProductQuantity.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+import { useItemContext } from './components/ItemContext'
+
+const ProductQuantity: React.FC = () => {
+  const { item } = useItemContext()
+
+  return <span className="c-muted-1 t-body">{item.quantity} un.</span>
+}
+
+export default ProductQuantity

--- a/react/ProductQuantity.tsx
+++ b/react/ProductQuantity.tsx
@@ -1,11 +1,19 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 
 import { useItemContext } from './components/ItemContext'
 
 const ProductQuantity: React.FC = () => {
   const { item } = useItemContext()
 
-  return <span className="c-muted-1 t-body">{item.quantity} un.</span>
+  return (
+    <span className="c-muted-1 t-body">
+      <FormattedMessage
+        id="store/product-list.quantity-units"
+        values={{ quantity: item.quantity }}
+      />
+    </span>
+  )
 }
 
 export default ProductQuantity

--- a/react/ProductQuantity.tsx
+++ b/react/ProductQuantity.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
 import { useItemContext } from './components/ItemContext'
 
+const CSS_HANDLES = ['productQuantityUnit'] as const
+
 const ProductQuantity: React.FC = () => {
   const { item } = useItemContext()
+  const cssHandles = useCssHandles(CSS_HANDLES)
 
   return (
-    <span className="c-muted-1 t-body">
+    <span className={`${cssHandles.productQuantityUnit} c-muted-1 t-body`}>
       <FormattedMessage
         id="store/product-list.quantity-units"
         values={{ quantity: item.quantity }}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -53,6 +53,9 @@
   "product-variations": {
     "component": "ProductVariations"
   },
+  "product-quantity": {
+    "component": "ProductQuantity"
+  },
   "quantity-selector": {
     "component": "QuantitySelector",
     "preview": {


### PR DESCRIPTION
#### What problem is this solving?
Adds the product quantity component that will be used in the new checkout. This PR also adds the `showListPrice` prop to the `Price` component, since we don't want to show it in the checkout listing.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32812/layout-da-p%C3%A1gina-de-checkout-no-io)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/76089000-b899a980-5f97-11ea-9eaa-fe3001d37e52.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
