### PR TITLE
Rename block to product-quantity-label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Rename block `product-quantity` to `product-quantity-label`.
 
-## [0.18.0] - 2020-03-06
+## [0.18.0] - 2020-03-06 [YANKED]
 ### Added
 - New component `ProductQuantity`.
 - Prop `showListPrice` to `Price` component.

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,7 +223,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `productPriceContainer`              |
 | `productPriceCurrency`               |
 | `productPrice`                       |
-| `productQuantityUnit`                |
+| `productQuantityLabel`               |
 | `productVariationsContainer`         |
 | `productVariationsItem`              |
 | `quantityDropdownContainer`          |

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,5 +7,5 @@
   "store/product-list.message.noLongerAvailable": "This product is no longer available.",
   "store/product-list.message.remove": "remove",
   "store/product-list.quantity-selector.remove": "Remove",
-  "store/product-list.quantity-units": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,5 +7,5 @@
   "store/product-list.message.noLongerAvailable": "Este producto no está disponible actualmente.",
   "store/product-list.message.remove": "retirar",
   "store/product-list.quantity-selector.remove": "Retirar",
-  "store/product-list.quantity-units": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,5 +7,5 @@
   "store/product-list.message.noLongerAvailable": "Este produto não está mais disponível.",
   "store/product-list.message.remove": "remover",
   "store/product-list.quantity-selector.remove": "Remover",
-  "store/product-list.quantity-units": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un."
 }

--- a/react/ProductQuantityLabel.tsx
+++ b/react/ProductQuantityLabel.tsx
@@ -13,7 +13,7 @@ const ProductQuantityLabel: React.FC = () => {
   return (
     <span className={`${cssHandles.productQuantityLabel} c-muted-1 t-body`}>
       <FormattedMessage
-        id="store/product-list.quantity-units"
+        id="store/product-list.quantity-label"
         values={{ quantity: item.quantity }}
       />
     </span>

--- a/react/ProductQuantityLabel.tsx
+++ b/react/ProductQuantityLabel.tsx
@@ -4,14 +4,14 @@ import { useCssHandles } from 'vtex.css-handles'
 
 import { useItemContext } from './components/ItemContext'
 
-const CSS_HANDLES = ['productQuantityUnit'] as const
+const CSS_HANDLES = ['productQuantityLabel'] as const
 
-const ProductQuantity: React.FC = () => {
+const ProductQuantityLabel: React.FC = () => {
   const { item } = useItemContext()
   const cssHandles = useCssHandles(CSS_HANDLES)
 
   return (
-    <span className={`${cssHandles.productQuantityUnit} c-muted-1 t-body`}>
+    <span className={`${cssHandles.productQuantityLabel} c-muted-1 t-body`}>
       <FormattedMessage
         id="store/product-list.quantity-units"
         values={{ quantity: item.quantity }}
@@ -20,4 +20,4 @@ const ProductQuantity: React.FC = () => {
   )
 }
 
-export default ProductQuantity
+export default ProductQuantityLabel

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -53,8 +53,8 @@
   "product-variations": {
     "component": "ProductVariations"
   },
-  "product-quantity": {
-    "component": "ProductQuantity"
+  "product-quantity-label": {
+    "component": "ProductQuantityLabel"
   },
   "quantity-selector": {
     "component": "QuantitySelector",


### PR DESCRIPTION
#### What problem is this solving?
Fixes a block name conflict with the [`vtex.product-quantity`](https://github.com/vtex-apps/product-quantity) app.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#/)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
