### PR TITLE
Add props variation and displayMode to Removebutton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Props `variation` and `displayMode` to `remove-button`.
 
 ## [0.19.4] - 2020-05-08
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,5 +7,6 @@
   "store/product-list.message.noLongerAvailable": "This product is no longer available.",
   "store/product-list.message.remove": "remove",
   "store/product-list.quantity-selector.remove": "Remove",
-  "store/product-list.quantity-label": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un.",
+  "store/product-list.delete-button.default-label": "Remove Product"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,5 +7,6 @@
   "store/product-list.message.noLongerAvailable": "Este producto no está disponible actualmente.",
   "store/product-list.message.remove": "retirar",
   "store/product-list.quantity-selector.remove": "Retirar",
-  "store/product-list.quantity-label": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un.",
+  "store/product-list.delete-button.default-label": "Eliminar Producto"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,5 +7,6 @@
   "store/product-list.message.noLongerAvailable": "Este produto não está mais disponível.",
   "store/product-list.message.remove": "remover",
   "store/product-list.quantity-selector.remove": "Remover",
-  "store/product-list.quantity-label": "{quantity} un."
+  "store/product-list.quantity-label": "{quantity} un.",
+  "store/product-list.delete-button.default-label": "Remover Produto"
 }

--- a/react/RemoveButton.tsx
+++ b/react/RemoveButton.tsx
@@ -1,19 +1,43 @@
-import React, { FunctionComponent } from 'react'
-import { IconDelete } from 'vtex.styleguide'
-import { useCssHandles } from 'vtex.css-handles'
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import { Loading } from 'vtex.render-runtime'
+import { useCssHandles } from 'vtex.css-handles'
+import { IconDelete, Button } from 'vtex.styleguide'
 
 import { useItemContext } from './ItemContext'
 import { opaque } from './utils/opaque'
 
 const CSS_HANDLES = ['removeButtonContainer', 'removeButton'] as const
 
-const RemoveButton: FunctionComponent = () => {
+type DisplayMode = 'icon-button' | 'text-button'
+type Variation =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'inverted-tertiary'
+  | 'danger'
+  | 'danger-tertiary'
+
+interface Props {
+  displayMode?: DisplayMode
+  variation?: Variation
+}
+
+function RemoveButton(props: Props) {
+  const { displayMode = 'icon-button', variation = 'danger' } = props
   const { item, loading, onRemove } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
 
   if (loading) {
     return <Loading />
+  }
+
+  if (displayMode === 'text-button') {
+    return (
+      <Button variation={variation} onClick={onRemove}>
+        <FormattedMessage id="store/product-list.delete-button.default-label" />
+      </Button>
+    )
   }
 
   return (

--- a/react/package.json
+++ b/react/package.json
@@ -39,7 +39,9 @@
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide",
+    "vtex.store-icons": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons",
+    "vtex.modal-layout": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.modal-layout@0.4.2/public/@types/vtex.modal-layout"
   },
   "version": "0.19.4"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6211,6 +6211,10 @@ vtex-tachyons@^3.2.0:
   version "0.4.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price#821e3f087065704d02ee28e4f41aada3d6cb46da"
 
+"vtex.modal-layout@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.modal-layout@0.4.2/public/@types/vtex.modal-layout":
+  version "0.4.2"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.modal-layout@0.4.2/public/@types/vtex.modal-layout#5b65c9daa51ace58ed29f768a938d0811b3f0091"
+
 "vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager":
   version "0.8.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager#3a4761c73364853954dd61a61d1d01260cbbf634"
@@ -6218,6 +6222,10 @@ vtex-tachyons@^3.2.0:
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime":
   version "8.100.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime#b94c966be2d1c3d8bc9f1caf2dd9f462d88e98d2"
+
+"vtex.store-icons@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons":
+  version "0.17.0"
+  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons#1da7ec2f89522d8c5ed3418fec8fbc82817499db"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide":
   version "9.116.0"


### PR DESCRIPTION
#### What problem is this solving?

Add the option to display the remove button as a normal button in order to create a confirmation modal to the action

What I did here to make it work was to add a `modal-trigger` instead of the actual button to remove the item and inside the modal, I just added the button. Since the modal is inside the item, it has all the needed context to make it work

### Notes

Documentation will be added later by @guerreirobeatriz because we need to reorganize this doc

#### How should this be manually tested?

1. [Workspace](https://confirmationmodal--storecomponents.myvtex.com/)
2. Add an item
3. Try to remove the item

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

Blocks used to implement this feature

```jsonc
{
  "modal-trigger#confirmation-modal": {
    "children": [
      "icon-delete",
      "modal-layout#confirmation-modal"
    ]
  },
  "modal-layout#confirmation-modal": {
    "children": [
      "modal-actions#confirmation-modal"    
    ]
  },
  "modal-actions#confirmation-modal": {
    "children": [
      "modal-actions.close",
      "remove-button"
    ]
  },
  "flex-layout.col#remove-button.mobile": {
    "children": ["modal-trigger#confirmation-modal"],
    "props": {
      "marginLeft": "3"
    }
  }
}
```
