### PR TITLE
Add app name in front of product-name block usage to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add app prefix to `product-name` block usage to avoid conflicts.
 
 ## [0.20.0] - 2020-05-19
 ### Added

--- a/store/blocks/common.jsonc
+++ b/store/blocks/common.jsonc
@@ -18,7 +18,9 @@
     }
   },
   "flex-layout.row#product-name": {
-    "children": ["product-name"]
+    // Using app prefix here because it might conflict with
+    // vtex.store-components:product-name
+    "children": ["vtex.product-list:product-name"]
   },
   "flex-layout.row#product-variations": {
     "children": ["product-variations"],


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

[Workspace](https://productnameconflict--storecomponents.myvtex.com/)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xUPGGoPAxV1xlRH1ok/giphy.gif)
