### PR TITLE
Bugfix/product name root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product List with rootPath in the URL
 
 ## [0.28.0] - 2021-01-19
 ### Added

--- a/react/ProductName.tsx
+++ b/react/ProductName.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from 'react'
 import React from 'react'
-import { Loading } from 'vtex.render-runtime'
+import { Loading, useRuntime } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useItemContext } from './ItemContext'
@@ -10,6 +10,7 @@ const CSS_HANDLES = ['productName'] as const
 
 const ProductName: FunctionComponent = () => {
   const { item, loading } = useItemContext()
+  const { rootPath = '' } = useRuntime()
   const handles = useCssHandles(CSS_HANDLES)
 
   if (loading) {
@@ -22,7 +23,7 @@ const ProductName: FunctionComponent = () => {
       className={`c-on-base t-title lh-copy fw6 no-underline fw5-m ${
         handles.productName
       } ${opaque(item.availability)}`}
-      href={item.detailUrl || undefined}
+      href={rootPath + item.detailUrl || undefined}
     >
       {item.name}
     </a>

--- a/react/ProductName.tsx
+++ b/react/ProductName.tsx
@@ -23,7 +23,7 @@ const ProductName: FunctionComponent = () => {
       className={`c-on-base t-title lh-copy fw6 no-underline fw5-m ${
         handles.productName
       } ${opaque(item.availability)}`}
-      href={rootPath + item.detailUrl || undefined}
+      href={item.detailUrl ? rootPath + item.detailUrl : undefined}
     >
       {item.name}
     </a>

--- a/react/__mocks__/vtex.render-runtime.tsx
+++ b/react/__mocks__/vtex.render-runtime.tsx
@@ -1,12 +1,9 @@
 import type { FunctionComponent } from 'react'
-import React from 'react'
+import React, { useState } from 'react'
 
 export const Loading: FunctionComponent = () => <div />
 
 export const useRuntime = () => {
-  let rootPath = ''
-  const setRootPath = (rP: string) => {
-    rootPath = rP
-  }
-  return { rootPath, setRootPath }
+  const [rootPath, setRootPath] = useState('')
+  return rootPath
 }

--- a/react/__mocks__/vtex.render-runtime.tsx
+++ b/react/__mocks__/vtex.render-runtime.tsx
@@ -5,5 +5,5 @@ export const Loading: FunctionComponent = () => <div />
 
 export const useRuntime = () => {
   const [rootPath, setRootPath] = useState('')
-  return rootPath
+  return { rootPath }
 }

--- a/react/__mocks__/vtex.render-runtime.tsx
+++ b/react/__mocks__/vtex.render-runtime.tsx
@@ -2,3 +2,11 @@ import type { FunctionComponent } from 'react'
 import React from 'react'
 
 export const Loading: FunctionComponent = () => <div />
+
+export const useRuntime = () => {
+  let rootPath = ''
+  const setRootPath = (rP: string) => {
+    rootPath = rP
+  }
+  return { rootPath, setRootPath }
+}


### PR DESCRIPTION
#### What problem is this solving?

Minicart product name without /country/ on the URL. (Akamai's fault, I'm sorry).

#### How to test it?

[Workspace](https://rootpath--samsungbr.myvtex.com/!)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/28419764/91781283-503b2600-ebd0-11ea-88d7-6cbab915c782.png)

#### How does this PR make you feel? 

![hahaha](https://media.giphy.com/media/QgawLg4F0hJJe/giphy.gif)
