### PR TITLE
CHK-323: Update product list to memoize individual items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Memoize product list items and avoid re-rendering unmodified items.
 
 ## [0.21.1] - 2020-08-26
 ### Fixed


### PR DESCRIPTION
#### What problem is this solving?

This fixes an performance issue with carts that are too big. Previously, the product list component would re-render every single item when one of them changed (think changing the quantity of the product, or removing an item), and this PR changes to only update the changed item and leave the other ones intact. This led from a change that lasted roughly 1 second to a few milliseconds to render.

#### How to test it?

You can use the same testing plan as vtex-apps/checkout-cart#61.

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

vtex-apps/render-runtime#555