### PR TITLE
CHK-353: Consistency when changing between `QuantitySelector` combobox and input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Consistency when changing `QuantitySelector` combobox and input
 
 ## [0.23.2] - 2020-09-16
 ### Added

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -16,6 +16,7 @@ const messages = defineMessages({
   },
 })
 
+const MAX_DROPDOWN_VALUE = 10
 const MAX_INPUT_LENGTH = 5
 
 enum SelectorType {
@@ -61,8 +62,8 @@ const getDropdownOptions = (maxValue: number, intl: InjectedIntl) => {
     ...range(1, limit + 1).map(idx => ({ value: idx, label: `${idx}` })),
   ]
 
-  if (maxValue >= 10) {
-    options.push({ value: 10, label: '10+' })
+  if (maxValue >= MAX_DROPDOWN_VALUE) {
+    options.push({ value: MAX_DROPDOWN_VALUE, label: `${MAX_DROPDOWN_VALUE}+` })
   }
 
   return options
@@ -84,7 +85,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
   intl,
 }) => {
   const [curSelector, setSelector] = useState(
-    value < 10 ? SelectorType.Dropdown : SelectorType.Input
+    value < MAX_DROPDOWN_VALUE ? SelectorType.Dropdown : SelectorType.Input
   )
   const [activeInput, setActiveInput] = useState(false)
 
@@ -98,7 +99,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
     const validatedValue = validateValue(value, maxValue)
     const displayValue = validateDisplayValue(value, maxValue)
 
-    if (validatedValue >= 10 && curSelector === SelectorType.Dropdown) {
+    if (validatedValue >= MAX_DROPDOWN_VALUE) {
       setSelector(SelectorType.Input)
     }
 
@@ -120,7 +121,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
 
     const validatedValue = validateValue(curDisplayValue, maxValue)
 
-    if (validatedValue < 10 && curSelector === SelectorType.Input) {
+    if (validatedValue < MAX_DROPDOWN_VALUE) {
       setSelector(SelectorType.Dropdown)
     }
 
@@ -133,7 +134,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
     !activeInput &&
     normalizedValue !== validateValue(curDisplayValue, maxValue)
   ) {
-    if (normalizedValue >= 10) {
+    if (normalizedValue >= MAX_DROPDOWN_VALUE) {
       setSelector(SelectorType.Input)
     }
     setDisplayValue(validateDisplayValue(`${normalizedValue}`, maxValue))

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -119,6 +119,11 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
     }
 
     const validatedValue = validateValue(curDisplayValue, maxValue)
+
+    if (validatedValue < 10 && curSelector === SelectorType.Input) {
+      setSelector(SelectorType.Dropdown)
+    }
+
     onChange(validatedValue)
   }
 


### PR DESCRIPTION
#### What problem is this solving?

When clicking on "10+" on dropdown, the component changes to an input, but after inserting a value lesser than 10 on input, the component won't change back to a dropdown, creating an inconsistent behavior.

Also, there is a small code quality refactor.

#### How to test it?

[Workspace](https://wdsrocha0productlistbug--checkoutio.myvtex.com/cart/add?sku=289)

#### Screenshots or example usage:

Before|After
-|-
<img src="https://user-images.githubusercontent.com/26108090/92334952-d9d37380-f068-11ea-9a9f-a0cc95fd69d1.gif" width="300" />|<img src="https://user-images.githubusercontent.com/26108090/92334932-b6a8c400-f068-11ea-8de5-15388b3cd58f.gif" width="300" />