### PR TITLE
Use 'IconDelete' from 'vtex.store-icons' instead of 'vtex.styleguide'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for customization of the `IconRemove` icon, since it now comes from `vtex.store-icons`.
 
 ## [0.21.2] - 2020-09-09
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,8 @@
     "vtex.device-detector": "0.x",
     "vtex.order-manager": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.checkout-graphql": "0.x"
+    "vtex.checkout-graphql": "0.x",
+    "vtex.store-icons": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/RemoveButton.tsx
+++ b/react/RemoveButton.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { Loading } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
-import { IconDelete, Button } from 'vtex.styleguide'
+import { Button } from 'vtex.styleguide'
+import { IconDelete } from 'vtex.store-icons'
 
 import { useItemContext } from './ItemContext'
 import { opaque } from './utils/opaque'
@@ -48,11 +49,12 @@ function RemoveButton(props: Props) {
     >
       <button
         id={`remove-button-${item.id}`}
+        style={{ color: '#727273' }}
         className={`${handles.removeButton} pointer bg-transparent bn pa2`}
         title="remove"
         onClick={onRemove}
       >
-        <IconDelete color="#727273" />
+        <IconDelete />
       </button>
     </div>
   )

--- a/react/__mocks__/vtex.store-icons.tsx
+++ b/react/__mocks__/vtex.store-icons.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const IconDelete = () => <div />

--- a/react/package.json
+++ b/react/package.json
@@ -37,11 +37,10 @@
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.0/public/@types/vtex.flex-layout",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.1.3/public/@types/vtex.format-currency",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
+    "vtex.modal-layout": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.modal-layout@0.4.2/public/@types/vtex.modal-layout",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.4/public/@types/vtex.order-manager",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide",
-    "vtex.store-icons": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons",
-    "vtex.modal-layout": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.modal-layout@0.4.2/public/@types/vtex.modal-layout"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide"
   },
   "version": "0.21.2"
 }

--- a/react/typings/vtex.store-icons.d.ts
+++ b/react/typings/vtex.store-icons.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.store-icons'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6223,10 +6223,6 @@ vtex-tachyons@^3.2.0:
   version "8.100.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.100.4/public/@types/vtex.render-runtime#b94c966be2d1c3d8bc9f1caf2dd9f462d88e98d2"
 
-"vtex.store-icons@http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons":
-  version "0.17.0"
-  resolved "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.store-icons@0.17.0/public/@types/vtex.store-icons#1da7ec2f89522d8c5ed3418fec8fbc82817499db"
-
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide":
   version "9.116.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.116.0/public/@types/vtex.styleguide#f17be9afb6ee66c71f2ea8d5ba81b2d18b2caa76"


### PR DESCRIPTION
#### What problem is this solving?

Currently this app is using the `IconDelete` component from `vtex.styleguide`, which makes customization using `iconspacks` as described at our [docs](https://vtex.io/docs/recipes/style/customizing-your-stores-icons/) impossible.

This PR makes the `RemoveButton` component use `IconDelete` from `vtex.store-icons`.

#### How to test it?

Go to [Workspace](https://victormiranda--storecomponents.myvtex.com/), add an item to the cart, and check the trash can icon in the product list. There should be no difference to the one you see at `master` workspace.

#### Screenshots or example usage:

Default look:

<img width="383" alt="Screen Shot 2020-09-10 at 17 48 30" src="https://user-images.githubusercontent.com/27777263/92803482-d8b68500-f38d-11ea-8bea-eb9b204ed841.png">

Customized icon:

<img width="517" alt="Screen Shot 2020-09-10 at 17 51 28" src="https://user-images.githubusercontent.com/27777263/92803918-4498ed80-f38e-11ea-98df-ea5e8d5277c8.png">

#### Related to / Depends on

Closes https://github.com/vtex-apps/store-discussion/issues/386.

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Lka8eCWBLInqw0fP2s/giphy.gif)
