### PR TITLE
Prop `unitPriceType` to `unit-price` block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Prop `unitPriceType` to `unit-price` block.
+
 ## [0.22.0] - 2020-09-11
 ### Added
 - Support for customization of the `IconRemove` icon, since it now comes from `vtex.store-icons`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -282,6 +282,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name   | Type     | Description                               | Default value |
 | ----------- | -------- | ----------------------------------------- | ------------- |
 | `textAlign` | `string` | Product unit prices position on the list. | `left`        |
+| `unitPriceType` | `enum` | Defines whether the price type should be displayed. Possible values are: `sellingPrice` or `price` | `price`        |
 | `unitPriceDisplay` | `enum` | Defines when the unit price should be displayed. Possible values are: `always` (unit price is always displayed) or `default` (unit price is only displayed when the number of products is greater than one). | `default`        |
 | `displayUnitListPrice` | `enum` | Defines whether the product list price should be displayed or not. Possible values are: `showWhenDifferent` (list price is displayed when it is different from the regular price) or`notShow` (list price is never displayed). | `notShow`        |
 

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -16,6 +16,7 @@ const CSS_HANDLES = [
 ] as const
 
 interface UnitPriceProps extends TextAlignProp {
+  unitPriceType: UnitPriceType
   unitPriceDisplay: UnitPriceDisplayType
   displayUnitListPrice: DisplayUnitListPriceType
 }
@@ -24,8 +25,11 @@ type UnitPriceDisplayType = 'always' | 'default'
 
 type DisplayUnitListPriceType = 'showWhenDifferent' | 'notShow'
 
+type UnitPriceType = 'price' | 'sellingPrice'
+
 const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
-  textAlign,
+  textAlign = 'left',
+  unitPriceType = 'price',
   unitPriceDisplay = 'default',
   displayUnitListPrice = 'notShow',
 }) => {
@@ -36,9 +40,10 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
     return null
   }
 
+  const unitPrice = item[unitPriceType] ?? 0
+
   return (item.quantity > 1 || unitPriceDisplay === 'always') &&
-    item.price &&
-    item.price > 0 ? (
+    unitPrice > 0 ? (
     <div
       id={`unit-price-${item.id}`}
       className={`t-mini c-muted-1 lh-title ${handles.unitPriceContainer} ${
@@ -46,7 +51,7 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
       } ${opaque(item.availability)} ${parseTextAlign(textAlign)}`}
     >
       {item.listPrice &&
-        item.price !== item.listPrice &&
+        unitPrice !== item.listPrice &&
         displayUnitListPrice === 'showWhenDifferent' && (
           <div className={`strike ${handles.unitListPrice}`}>
             <FormattedCurrency value={item.listPrice / 100} />
@@ -57,7 +62,7 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
         values={{
           price: (
             <div className={`${handles.unitPricePerUnitCurrency} dib`}>
-              <FormattedCurrency value={item.price / 100} />
+              <FormattedCurrency value={unitPrice / 100} />
             </div>
           ),
           perMeasurementUnit: (
@@ -74,15 +79,11 @@ const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
   ) : null
 }
 
-UnitPrice.defaultProps = {
-  textAlign: 'left',
-}
-
 UnitPrice.schema = {
   properties: {
     textAlign: {
       type: 'string',
-      default: UnitPrice.defaultProps.textAlign,
+      default: 'left',
       isLayout: true,
     },
   },


### PR DESCRIPTION
#### What problem is this solving?

We need a solution to show the correct price to the total price makes sense.

#### How to test it?

[Product Page - Workspace](https://mizu--carrefourbrfood.myvtex.com/wrap-chia-e-quinoa-pullman-198g-5914779/p)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49173685/93129600-ab2c4d00-f6a7-11ea-9f39-36d6db09ec3c.png)
![image](https://user-images.githubusercontent.com/49173685/93129691-d747ce00-f6a7-11ea-8d87-9aab1b825c43.png)

#### How does this PR make you feel?

![image](https://user-images.githubusercontent.com/49173685/93130173-8c7a8600-f6a8-11ea-9114-2c689fe2ba75.png)
