### PR TITLE
Add attribute lazy to product images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Attribute `lazy` to product images.
 
 ## [0.23.1] - 2020-09-16
 ### Fixed

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -59,6 +59,7 @@ const Image: FunctionComponent<ImageProps> = ({ width = 96 }) => {
         {imageUrl ? (
           <img
             className={`${handles.productImage} br2`}
+            loading="lazy"
             alt={item.name || undefined}
             src={imageUrl}
             width="100%"

--- a/react/typings/react.d.ts
+++ b/react/typings/react.d.ts
@@ -1,0 +1,7 @@
+import 'react'
+
+declare module 'react' {
+  interface ImgHTMLAttributes<T> extends HTMLAttributes<T> {
+    loading?: 'auto' | 'eager' | 'lazy'
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

Avoid loading all cart item images at once, make them load lazily.

#### How to test it?

https://breno--carrefourbrfood.myvtex.com/cart
#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
