### PR TITLE
Avoid Dropdown error message by using placeholder as an empty space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Avoid Dropdown error message by using placeholder as empty space.
 
 ## [0.23.0] - 2020-09-14
 

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -147,7 +147,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
             size="small"
             value={normalizedValue}
             onChange={(event: any) => handleDropdownChange(event.target.value)}
-            placeholder=""
+            placeholder=" "
             disabled={disabled}
           />
         </div>
@@ -158,7 +158,7 @@ const QuantitySelector: FunctionComponent<Props & InjectedIntlProps> = ({
             options={dropdownOptions}
             value={normalizedValue}
             onChange={(event: any) => handleDropdownChange(event.target.value)}
-            placeholder=""
+            placeholder=" "
             disabled={disabled}
           />
         </div>


### PR DESCRIPTION
#### What problem is this solving?

For each item in the cart, it would trigger an error message by the Styleguide's Dropdown component.

Error message triggered by the Dropdown component:
https://github.com/vtex/styleguide/blob/97dabb8611414e749da6a7a7e63a4e07e5693b75/react/components/Dropdown/index.js#L58-L67

This console.log takes time to process, making cart slower.

#### How to test it?

https://breno--carrefourbrfood.myvtex.com/cart

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
