### PR TITLE
ItemContextProvider as a default import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- ItemContextProvider as a default import
+
 ## [0.23.2] - 2020-09-16
 ### Added
 - Attribute `lazy` to product images.

--- a/react/ItemContext.tsx
+++ b/react/ItemContext.tsx
@@ -28,4 +28,4 @@ export const useItemContext = () => {
   return context
 }
 
-export default { useItemContext }
+export default { useItemContext, ItemContextProvider }


### PR DESCRIPTION
#### What problem is this solving?

I'm doing a custom product-list and to make it I need to import the `ItemContextProvider` on my app.

#### How to test it?

[Workspace](https://ecom7522--carrefourbr.myvtex.com)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/49173685/93382821-15c0c280-f839-11ea-99ff-425cb2d8868b.png)

