### PR TITLE
Remove default value from renderOnView.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Set useRenderOnView false by default to make it compatible with previous ProductList instances.
 
-## [0.24.1] - 2020-10-02
+## [0.24.1] - 2020-10-02 [YANKED]
 ### Fixed
 - Optimize ProductList initial render time with useRenderOnView hook.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set useRenderOnView false by default.
 
 ## [0.24.1] - 2020-10-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Set useRenderOnView false by default.
+- Set useRenderOnView false by default to make it compatible with previous ProductList instances.
 
 ## [0.24.1] - 2020-10-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Set useRenderOnView false by default to make it compatible with previous ProductList instances.
 
-## [0.24.1] - 2020-10-02 [YANKED]
 ### Fixed
 - Optimize ProductList initial render time with useRenderOnView hook.
 

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -112,7 +112,7 @@ const ProductGroup: StorefrontFunctionComponent<Props> = props => {
 }
 
 const ProductList: StorefrontFunctionComponent<Props> = props => {
-  const { items, renderOnView = true } = props
+  const { items } = props
 
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -148,7 +148,6 @@ const ProductList: StorefrontFunctionComponent<Props> = props => {
         <ProductGroup
           key={group.reduce((result, item) => `${result}#${item.id}`, '')}
           {...props}
-          renderOnView={renderOnView}
           items={group}
         />
       ))}
@@ -166,7 +165,6 @@ const ProductList: StorefrontFunctionComponent<Props> = props => {
         <ProductGroup
           key={group.reduce((result, item) => `${result}#${item.id}`, '')}
           {...props}
-          renderOnView={renderOnView}
           items={group}
         />
       ))}

--- a/react/__tests__/ProductList.test.tsx
+++ b/react/__tests__/ProductList.test.tsx
@@ -35,7 +35,6 @@ describe('Product List', () => {
         loading={false}
         onQuantityChange={() => {}}
         onRemove={() => {}}
-        renderOnView={false}
       >
         <ListItem />
       </ProductList>
@@ -55,7 +54,6 @@ describe('Product List', () => {
         loading={false}
         onQuantityChange={() => {}}
         onRemove={mockHandleRemove}
-        renderOnView={false}
       >
         <ListItem />
       </ProductList>
@@ -75,7 +73,6 @@ describe('Product List', () => {
         loading={false}
         onQuantityChange={() => {}}
         onRemove={() => {}}
-        renderOnView={false}
       >
         <ListItem />
       </ProductList>
@@ -92,7 +89,6 @@ describe('Product List', () => {
         loading={false}
         onQuantityChange={() => {}}
         onRemove={() => {}}
-        renderOnView={false}
       >
         <ListItem />
       </ProductList>
@@ -108,7 +104,6 @@ describe('Product List', () => {
         loading={false}
         onQuantityChange={() => {}}
         onRemove={() => {}}
-        renderOnView={false}
       >
         <ListItem />
       </ProductList>


### PR DESCRIPTION
#### What problem is this solving?

**VTEX IO - COMPRAS** healthcheck was failing due to the fact that `useRenderOnView` is a kind of lazy load and, at first, the minicart was loading blank. It made me realize that this change should be compatible with previous `ProductList` instances. So I'm making the use of `renderOnView` `false` by default.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://productlist--ioqa.myvtexdev.com)

In order to test properly you should run HealthCheck-IO using the workspace above. You should have permissions to read that repository.

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/11471014/95241205-d22bf980-07e3-11eb-8f6f-3d407ce13d7b.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/S4mv3vJ4iFjvq/giphy.gif)
