### PR TITLE
Use sellingPrice value by default in UnitPrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change unitPriceType prop from UnitPrice default value to 'sellingPrice'.
 
 ## [0.24.2] - 2020-10-06
 ### Fixed

--- a/react/UnitPrice.tsx
+++ b/react/UnitPrice.tsx
@@ -29,7 +29,7 @@ type UnitPriceType = 'price' | 'sellingPrice'
 
 const UnitPrice: StorefrontFunctionComponent<UnitPriceProps> = ({
   textAlign = 'left',
-  unitPriceType = 'price',
+  unitPriceType = 'sellingPrice',
   unitPriceDisplay = 'default',
   displayUnitListPrice = 'notShow',
 }) => {


### PR DESCRIPTION
#### What problem is this solving?

The unit price wasn't using `sellingPrice` by default.

#### How to test it?

Add a product to your cart and increase its unit to more than one. Apply a coupon (like `teste50p`). The unit price showed should reflect the discount of the coupon (what means it's now using `sellingPrice` as default value).

[Workspace](https://chk339--checkoutio.myvtex.com/cart)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![ss](https://user-images.githubusercontent.com/11471014/95880344-c8f3dd00-0d4d-11eb-93ee-74206d10faef.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif)
