### PR TITLE
fix key of ItemContextWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `ItemContextWrapper` key.
 ## [0.27.1] - 2020-12-18
 ### Fixed
 - Item not being removed when changing quantity to zero in dropdown.

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -106,7 +106,7 @@ const ProductGroup: React.FC<Props> = (props) => {
     <>
       {items.map((item: ItemWithIndex) => (
         <ItemContextWrapper
-          key={item.uniqueId + (item.sellingPrice?.toString() ?? '')}
+          key={`${item.uniqueId}-${item.sellingPrice}-${item.index}`}
           item={item}
           itemIndex={item.index}
           shouldAllowManualPrice={shouldAllowManualPrice}


### PR DESCRIPTION
#### What problem is this solving?
This fix stop the duplication of items on `product-list`.

<!--- What is the motivation and context for this change? -->

#### How to test it?
Go to this [Workspace](https://ecom8494--carrefourbrfood.myvtex.com/)
Add items on the wishlist and go to my lists page [my lists](https://i.imgur.com/rEVmwLU.png)
Then click at [buy list button](https://i.imgur.com/bO7acJK.png)
On cart the first product shouldn't be duplicated.

This same test can be done at [master workspace](carrefourbrfood.myvtex.com/cart) to see the product duplicated.
[master duplicated product](https://i.imgur.com/Z9bqwD6.png)

<!--- Don't forget to add a link to a Workspace where this branch is linked -->
#### Screenshots or example usage:
This video shows the bug on both cenarios.
[video](https://www.loom.com/share/05702082c08d4f9aa28e2e0f23183712)