### PR TITLE
CHK-406: Create quantity stepper component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `mode` to `quantity-selector` block and `QuantityStepper` component.
 
 ## [0.26.1] - 2020-12-07
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -310,8 +310,14 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 
 | Prop name              | Type      | Description                                                                                                                                                                                                                                     | Default value |
 | ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `variation`   | `enum`    | Variation for the button visual proeminence based on the[VTEX Styleguide](https://styleguide.vtex.com/#/Components/Forms/Button). Possible values are: `primary`, `secondary`, `tertiary`, `inverted-tertiary`, `danger` and `danger-tertiary`. | `danger`    |
+| `variation`   | `enum`    | Variation for the button visual proeminence based on the [VTEX Styleguide](https://styleguide.vtex.com/#/Components/Forms/Button). Possible values are: `primary`, `secondary`, `tertiary`, `inverted-tertiary`, `danger` and `danger-tertiary`. | `danger`    |
 | `displayMode` | `enum`  | Defines how the remove button should be displayed. Possible values are: `icon-button` (to render an icon button) and `text-button` (to render a text message button). If you desire to [create a modal in the remove button](https://vtex.io/docs/recipes/templates/creating-modals-using-icons/), use the `icon-button` value. | `icon-button` | 
+
+### `quantity-selector` props
+
+| Prop name | Type | Description | Default value |
+| --- | --- | --- | --- |
+| `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
 
 ## Customization
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,5 +19,8 @@
   "store/product-list.applyManualPrice": "ok",
   "store/product-list.quantitySelector.label": "{quantity} {measurementUnit}",
   "store/product-list.quantitySelector.maxValueLabel": "{quantity} {measurementUnit} +",
-  "store/product-list.quantityUnitMultiplierMismatch": "This product is sold by fractions of {unitMultiplier}{measurementUnit}. Given that, the inserted quantity has been rounded to {roundedValue}{measurementUnit}."
+  "store/product-list.quantityUnitMultiplierMismatch": "This product is sold by fractions of {unitMultiplier}{measurementUnit}. Given that, the inserted quantity has been rounded to {roundedValue}{measurementUnit}.",
+  "store/product-list.quantityStepper.label": "Product quantity",
+  "store/product-list.quantityStepper.increaseQuantity": "Increase quantity",
+  "store/product-list.quantityStepper.decreaseQuantity": "Decrease quantity"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -19,5 +19,8 @@
   "store/product-list.applyManualPrice": "Aplicar",
   "store/product-list.quantitySelector.label": "{quantity} {measurementUnit}",
   "store/product-list.quantitySelector.maxValueLabel": "{quantity} {measurementUnit} +",
-  "store/product-list.quantityUnitMultiplierMismatch": "Este producto se vende por fracciones de {unitMultiplier}{measurementUnit}. Por lo tanto, la cantidad ingresada se ha redondeado a {roundedValue}{measurementUnit}."
+  "store/product-list.quantityUnitMultiplierMismatch": "Este producto se vende por fracciones de {unitMultiplier}{measurementUnit}. Por lo tanto, la cantidad ingresada se ha redondeado a {roundedValue}{measurementUnit}.",
+  "store/product-list.quantityStepper.label": "Cantidad de producto",
+  "store/product-list.quantityStepper.increaseQuantity": "Aumentar la cantidad",
+  "store/product-list.quantityStepper.decreaseQuantity": "Cantidad decreciente"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,5 +19,8 @@
   "store/product-list.applyManualPrice": "Aplicar",
   "store/product-list.quantitySelector.label": "{quantity} {measurementUnit}",
   "store/product-list.quantitySelector.maxValueLabel": "{quantity} {measurementUnit} +",
-  "store/product-list.quantityUnitMultiplierMismatch": "Esse produto é vendido por frações de {unitMultiplier}{measurementUnit}. Por isso, a quantidade inserida foi arredondada para {roundedValue}{measurementUnit}."
+  "store/product-list.quantityUnitMultiplierMismatch": "Esse produto é vendido por frações de {unitMultiplier}{measurementUnit}. Por isso, a quantidade inserida foi arredondada para {roundedValue}{measurementUnit}.",
+  "store/product-list.quantityStepper.label": "Quantidade do produto",
+  "store/product-list.quantityStepper.increaseQuantity": "Aumentar quantidade",
+  "store/product-list.quantityStepper.decreaseQuantity": "Decrementar quantidade"
 }

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -1,9 +1,11 @@
-import type { FunctionComponent } from 'react'
+import type { VFC } from 'react'
 import React from 'react'
+import classnames from 'classnames'
 import { Loading } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
 
 import Selector from './components/QuantitySelector'
+import QuantityStepper from './components/QuantityStepper'
 import { useItemContext } from './ItemContext'
 import { AVAILABLE } from './constants/Availability'
 import { opaque } from './utils/opaque'
@@ -12,7 +14,13 @@ import styles from './styles.css'
 const MAX_ITEM_QUANTITY = 99999
 const CSS_HANDLES = ['quantitySelectorContainer'] as const
 
-const QuantitySelector: FunctionComponent = () => {
+type QuantitySelectorMode = 'default' | 'stepper'
+
+interface Props {
+  mode?: QuantitySelectorMode
+}
+
+const QuantitySelector: VFC<Props> = ({ mode = 'default' }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -20,11 +28,37 @@ const QuantitySelector: FunctionComponent = () => {
     return <Loading />
   }
 
+  if (mode === 'stepper') {
+    return (
+      <div
+        className={classnames(
+          opaque(item.availability),
+          handles.quantitySelectorContainer,
+          styles.quantity,
+          styles.quantityStepper
+        )}
+      >
+        <QuantityStepper
+          id={item.id}
+          value={item.quantity}
+          maxValue={MAX_ITEM_QUANTITY}
+          onChange={onQuantityChange}
+          disabled={item.availability !== AVAILABLE}
+          unitMultiplier={item.unitMultiplier ?? undefined}
+          measurementUnit={item.measurementUnit ?? undefined}
+        />
+      </div>
+    )
+  }
+
   return (
     <div
-      className={`${opaque(item.availability)} ${
-        handles.quantitySelectorContainer
-      } ${styles.quantity} ${styles.quantitySelector}`}
+      className={classnames(
+        opaque(item.availability),
+        handles.quantitySelectorContainer,
+        styles.quantity,
+        styles.quantitySelector
+      )}
     >
       <Selector
         id={item.id}

--- a/react/components/DecreaseIcon.tsx
+++ b/react/components/DecreaseIcon.tsx
@@ -1,0 +1,12 @@
+import type { VFC } from 'react'
+import React from 'react'
+
+const DecreaseIcon: VFC = () => {
+  return (
+    <svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M1.333 9.334h13.334V7.11H1.333v2.223z" fill="currentColor" />
+    </svg>
+  )
+}
+
+export default DecreaseIcon

--- a/react/components/IncreaseIcon.tsx
+++ b/react/components/IncreaseIcon.tsx
@@ -1,0 +1,21 @@
+import type { VFC } from 'react'
+import React from 'react'
+
+const IncreaseIcon: VFC = () => {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M14.6666 6.88905H9.11103V1.3335H6.88881V6.88905H1.33325V9.11127H6.88881V14.6668H9.11103V9.11127H14.6666V6.88905Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+export default IncreaseIcon

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react'
-import React, { useState, Fragment, useEffect, useContext } from 'react'
+import React, { useState, Fragment, useEffect } from 'react'
 import type { IntlShape } from 'react-intl'
 import { defineMessages, useIntl } from 'react-intl'
-import { Dropdown, Input, ToastContext } from 'vtex.styleguide'
+import { Dropdown, Input } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 
-import { parseValue, parseDisplayValue, normalizeValue } from './utils'
+import { parseDisplayValue } from './utils'
 import useQuantitySelectorState from './useQuantitySelectorState'
 
 const range = (startValue: number, endNumber: number) => {
@@ -117,7 +117,7 @@ const QuantitySelector: FC<Props> = ({
     minValue: 1,
   })
 
-  const normalizedValue = normalizeValue(value, maxValue)
+  const normalizedValue = Math.min(value, maxValue)
 
   const [curDisplayValue, setDisplayValue] = useState(
     intl.formatNumber(

--- a/react/components/QuantityStepper.css
+++ b/react/components/QuantityStepper.css
@@ -1,0 +1,3 @@
+.inputContainer {
+  width: 6rem;
+}

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -1,0 +1,201 @@
+import type { VFC } from 'react'
+import React, { useState, useEffect } from 'react'
+import { FormattedMessage, useIntl, defineMessages } from 'react-intl'
+import classnames from 'classnames'
+
+import VisuallyHidden from './VisuallyHidden'
+import IncreaseIcon from './IncreaseIcon'
+import DecreaseIcon from './DecreaseIcon'
+import { normalizeValue, parseDisplayValue } from './utils'
+import useQuantitySelectorState from './useQuantitySelectorState'
+import styles from './QuantityStepper.css'
+
+const messages = defineMessages({
+  increaseQuantity: {
+    id: 'store/product-list.quantityStepper.increaseQuantity',
+  },
+  decreaseQuantity: {
+    id: 'store/product-list.quantityStepper.decreaseQuantity',
+  },
+})
+
+interface Props {
+  id?: string
+  value?: number
+  maxValue?: number
+  onChange?: (value: number) => void
+  disabled?: boolean
+  unitMultiplier?: number
+  measurementUnit?: string
+}
+
+const QuantityStepper: VFC<Props> = ({
+  id,
+  value = 1,
+  maxValue,
+  onChange,
+  disabled,
+  unitMultiplier = 1,
+  measurementUnit = 'un',
+}) => {
+  const intl = useIntl()
+
+  const normalizedValue = normalizeValue(value, maxValue)
+
+  const [getUpdatedValue] = useQuantitySelectorState({
+    maxValue,
+    measurementUnit,
+  })
+
+  const [focused, setFocused] = useState(false)
+
+  const [currentValue, setCurrentValue] = useState(
+    intl.formatNumber(
+      parseDisplayValue({
+        value: normalizedValue.toString(),
+        maxValue,
+        unitMultiplier,
+      }),
+      { useGrouping: false }
+    )
+  )
+
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
+    evt
+  ) => {
+    setCurrentValue(evt.target.value)
+  }
+
+  const handleInputBlur = () => {
+    const { validatedValue, validatedDisplayValue } = getUpdatedValue({
+      value: currentValue,
+      unitMultiplier,
+    })
+
+    onChange?.(validatedValue)
+
+    setCurrentValue(validatedDisplayValue)
+    setFocused(false)
+  }
+
+  const handleDecrease: React.MouseEventHandler = (evt) => {
+    evt.preventDefault()
+
+    const parsedValue = parseDisplayValue({
+      value: normalizedValue.toString(),
+      maxValue,
+      unitMultiplier,
+    })
+
+    const { validatedValue, validatedDisplayValue } = getUpdatedValue({
+      value: (parsedValue - unitMultiplier).toString(),
+      unitMultiplier,
+    })
+
+    onChange?.(validatedValue)
+    setCurrentValue(validatedDisplayValue)
+  }
+
+  const handleIncrease: React.MouseEventHandler = (evt) => {
+    evt.preventDefault()
+
+    const parsedValue = parseDisplayValue({
+      value: normalizedValue.toString(),
+      maxValue,
+      unitMultiplier,
+    })
+
+    const { validatedValue, validatedDisplayValue } = getUpdatedValue({
+      value: (parsedValue + unitMultiplier).toString(),
+      unitMultiplier,
+    })
+
+    onChange?.(validatedValue)
+    setCurrentValue(validatedDisplayValue)
+  }
+
+  useEffect(() => {
+    if (focused) {
+      return
+    }
+
+    setCurrentValue(
+      intl.formatNumber(
+        parseDisplayValue({
+          value: normalizedValue.toString(),
+          maxValue,
+          unitMultiplier,
+        }),
+        { useGrouping: false }
+      )
+    )
+  }, [focused, intl, normalizedValue, maxValue, unitMultiplier])
+
+  const uniqueId = id ? `product-list-quantity-stepper-${id}` : undefined
+
+  return (
+    <div className="flex">
+      <button
+        className={classnames(
+          'pa4 ba br2 br--left flex items-center justify-center',
+          {
+            'c-muted-1 b--muted-4 hover-b--muted-3 bg-muted-5 hover-bg-muted-4 pointer': !disabled,
+            'bg-muted-5 c-muted-3 b--muted-4': disabled,
+          }
+        )}
+        aria-label={intl.formatMessage(messages.decreaseQuantity)}
+        disabled={disabled}
+        onClick={handleDecrease}
+      >
+        <DecreaseIcon />
+      </button>
+      <VisuallyHidden>
+        <label htmlFor={uniqueId}>
+          <FormattedMessage id="store/product-list.quantityStepper.label" />
+        </label>
+      </VisuallyHidden>
+      <div
+        className={classnames(
+          styles.inputContainer,
+          'flex-auto flex-shrink-0 flex items-center pv1 bt bb ph5',
+          {
+            'c-muted-3 b--muted-4': disabled,
+            'b--muted-4 hover-b--muted-3': !disabled,
+          }
+        )}
+      >
+        <input
+          className={classnames('flex-auto h-100 bn bg-transparent', {
+            tc: measurementUnit === 'un',
+            tr: measurementUnit !== 'un',
+          })}
+          id={uniqueId}
+          disabled={disabled}
+          value={currentValue}
+          onChange={handleInputChange}
+          onFocus={() => setFocused(true)}
+          onBlur={handleInputBlur}
+        />
+        {measurementUnit !== 'un' && (
+          <span className="c-muted-1 ml3">{measurementUnit}</span>
+        )}
+      </div>
+      <button
+        className={classnames(
+          'pa4 ba br2 br--right flex items-center justify-center',
+          {
+            'c-action-primary b--muted-4 hover-b--muted-3 bg-base hover-bg-muted-5 pointer': !disabled,
+            'bg-muted-5 c-muted-3 b--muted-4': disabled,
+          }
+        )}
+        aria-label={intl.formatMessage(messages.increaseQuantity)}
+        disabled={disabled}
+        onClick={handleIncrease}
+      >
+        <IncreaseIcon />
+      </button>
+    </div>
+  )
+}
+
+export default QuantityStepper

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -45,6 +45,7 @@ const QuantityStepper: VFC<Props> = ({
   const [getUpdatedValue] = useQuantitySelectorState({
     maxValue,
     measurementUnit,
+    minValue: 1,
   })
 
   const [focused, setFocused] = useState(false)
@@ -90,6 +91,7 @@ const QuantityStepper: VFC<Props> = ({
     const { validatedValue, validatedDisplayValue } = getUpdatedValue({
       value: (parsedValue - unitMultiplier).toString(),
       unitMultiplier,
+      minValue: 0,
     })
 
     onChange?.(validatedValue)

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -6,7 +6,7 @@ import classnames from 'classnames'
 import VisuallyHidden from './VisuallyHidden'
 import IncreaseIcon from './IncreaseIcon'
 import DecreaseIcon from './DecreaseIcon'
-import { normalizeValue, parseDisplayValue } from './utils'
+import { parseDisplayValue } from './utils'
 import useQuantitySelectorState from './useQuantitySelectorState'
 import styles from './QuantityStepper.css'
 
@@ -40,7 +40,7 @@ const QuantityStepper: VFC<Props> = ({
 }) => {
   const intl = useIntl()
 
-  const normalizedValue = normalizeValue(value, maxValue)
+  const normalizedValue = Math.min(value, maxValue ?? value)
 
   const [getUpdatedValue] = useQuantitySelectorState({
     maxValue,

--- a/react/components/VisuallyHidden.css
+++ b/react/components/VisuallyHidden.css
@@ -1,0 +1,15 @@
+.visuallyHidden {
+  /**
+   * Visually hidden styles, equivalent to
+   * the `sr-only` class of TailwindCSS: https://tailwindcss.com/docs/screen-readers#class-reference
+   */
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  clip: rect(0 0 0 0);
+  width: 2px;
+  height: 2px;
+  margin: -2px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+}

--- a/react/components/VisuallyHidden.tsx
+++ b/react/components/VisuallyHidden.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react'
+import React from 'react'
+
+import styles from './VisuallyHidden.css'
+
+const VisuallyHidden: FC = ({ children }) => {
+  return <div className={styles.visuallyHidden}>{children}</div>
+}
+
+export default VisuallyHidden

--- a/react/components/__tests__/QuantityStepper.test.tsx
+++ b/react/components/__tests__/QuantityStepper.test.tsx
@@ -1,0 +1,195 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@vtex/test-tools/react'
+import { ToastContext } from '@vtex/styleguide/lib/ToastProvider'
+
+import QuantityStepper from '../QuantityStepper'
+
+describe('<QuantityStepper />', () => {
+  it('should allow use to type the quantity', () => {
+    const onChange = jest.fn()
+
+    render(<QuantityStepper id="1" value={1} onChange={onChange} />)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('1')
+
+    fireEvent.change(input, { target: { value: '10' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith(10)
+    expect(input).toHaveValue('10')
+  })
+
+  it('should display toast when rounding values', () => {
+    const onChange = jest.fn()
+    const showToast = jest.fn()
+
+    render(
+      <ToastContext.Provider value={{ showToast }}>
+        <QuantityStepper id="1" value={1} onChange={onChange} />
+      </ToastContext.Provider>
+    )
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    fireEvent.change(input, { target: { value: '1.9' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith(2)
+    expect(input).toHaveValue('2')
+    expect(showToast).toHaveBeenCalledTimes(1)
+    expect(showToast).toHaveBeenCalledWith(
+      'This product is sold by fractions of 1un. Given that, the inserted quantity has been rounded to 2un.'
+    )
+  })
+
+  it('should increase quantity by one when pressing the increase button', () => {
+    const onChange = jest.fn()
+
+    render(<QuantityStepper id="1" value={1} onChange={onChange} />)
+
+    const increaseButton = screen.getByRole('button', {
+      name: /Increase quantity/i,
+    })
+
+    fireEvent.click(increaseButton)
+
+    expect(onChange).toHaveBeenCalledWith(2)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('2')
+  })
+
+  it('should decrease quantity by one when pressing the decrease button', () => {
+    const onChange = jest.fn()
+
+    render(<QuantityStepper id="1" value={2} onChange={onChange} />)
+
+    const decreaseButton = screen.getByRole('button', {
+      name: /Decrease quantity/i,
+    })
+
+    fireEvent.click(decreaseButton)
+
+    expect(onChange).toHaveBeenCalledWith(1)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('1')
+  })
+
+  it('should update input value when value prop changes', () => {
+    const { rerender } = render(<QuantityStepper id="1" value={1} />)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('1')
+
+    rerender(<QuantityStepper id="1" value={2} />)
+
+    expect(input).toHaveValue('2')
+  })
+
+  it('should not update input value when input is focused', () => {
+    const { rerender } = render(<QuantityStepper id="1" value={1} />)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('1')
+
+    fireEvent.focus(input)
+
+    rerender(<QuantityStepper id="1" value={2} />)
+
+    expect(input).toHaveValue('1')
+
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue('2')
+  })
+
+  it('can handle unit multipliers changes in the input', () => {
+    const onChange = jest.fn()
+    const showToast = jest.fn()
+
+    render(
+      <ToastContext.Provider value={{ showToast }}>
+        <QuantityStepper
+          id="1"
+          value={1}
+          onChange={onChange}
+          unitMultiplier={0.5}
+        />
+      </ToastContext.Provider>
+    )
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('0.5')
+
+    fireEvent.change(input, { target: { value: '1.4' } })
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue('1.5')
+    expect(onChange).toHaveBeenLastCalledWith(3)
+    expect(showToast).toHaveBeenLastCalledWith(
+      'This product is sold by fractions of 0.5un. Given that, the inserted quantity has been rounded to 1.5un.'
+    )
+  })
+
+  it('can handle increments of unit multiplier in increase and decrease button', () => {
+    const onChange = jest.fn()
+
+    const { rerender } = render(
+      <QuantityStepper
+        id="1"
+        value={1}
+        onChange={onChange}
+        unitMultiplier={0.5}
+      />
+    )
+
+    const increaseButton = screen.getByRole('button', {
+      name: /increase quantity/i,
+    })
+
+    const decreaseButton = screen.getByRole('button', {
+      name: /decrease quantity/i,
+    })
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    expect(input).toHaveValue('0.5')
+
+    fireEvent.click(increaseButton)
+
+    expect(input).toHaveValue('1')
+    expect(onChange).toHaveBeenLastCalledWith(2)
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <QuantityStepper
+        id="1"
+        value={2}
+        onChange={onChange}
+        unitMultiplier={0.5}
+      />
+    )
+
+    fireEvent.click(decreaseButton)
+
+    expect(input).toHaveValue('0.5')
+    expect(onChange).toHaveBeenLastCalledWith(1)
+
+    expect(onChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('should display measurement unit alongside input', () => {
+    render(<QuantityStepper id="1" value={1} measurementUnit="kg" />)
+
+    expect(screen.getByText('kg')).toBeInTheDocument()
+  })
+})

--- a/react/components/__tests__/QuantityStepper.test.tsx
+++ b/react/components/__tests__/QuantityStepper.test.tsx
@@ -192,4 +192,53 @@ describe('<QuantityStepper />', () => {
 
     expect(screen.getByText('kg')).toBeInTheDocument()
   })
+
+  it('should remove item when decreasing quantity with button', () => {
+    const onChange = jest.fn()
+
+    render(<QuantityStepper id="1" value={1} onChange={onChange} />)
+
+    const decreaseButton = screen.getByLabelText(/decrease quantity/i)
+
+    fireEvent.click(decreaseButton)
+
+    expect(onChange).toHaveBeenCalledWith(0)
+  })
+
+  it("shouldn't show toast when typed number isn't a number", () => {
+    const showToast = jest.fn()
+    const onChange = jest.fn()
+
+    render(
+      <ToastContext.Provider value={{ showToast }}>
+        <QuantityStepper
+          id="1"
+          value={1}
+          unitMultiplier={0.5}
+          onChange={onChange}
+        />
+      </ToastContext.Provider>
+    )
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    fireEvent.change(input, { target: { value: 'abc' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith(1)
+    expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it("shouldn't remove product when quantity is rounded to minimum value", () => {
+    const onChange = jest.fn()
+
+    render(<QuantityStepper id="1" value={1} onChange={onChange} />)
+
+    const input = screen.getByLabelText(/product quantity/i)
+
+    fireEvent.change(input, { target: { value: '0.1' } })
+    fireEvent.blur(input)
+
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
 })

--- a/react/components/useQuantitySelectorState.ts
+++ b/react/components/useQuantitySelectorState.ts
@@ -1,0 +1,77 @@
+import { useContext, useCallback } from 'react'
+import { ToastContext } from 'vtex.styleguide'
+import { useIntl } from 'react-intl'
+
+import { parseValue, parseDisplayValue } from './utils'
+
+const useQuantitySelectorState = ({
+  maxValue,
+  measurementUnit,
+  minValue = 0,
+}: {
+  maxValue?: number
+  minValue?: number
+  measurementUnit?: string
+}) => {
+  const { showToast } = useContext(ToastContext)
+  const intl = useIntl()
+
+  const onChange = useCallback(
+    ({
+      value,
+      unitMultiplier,
+      displayUnitMultiplier = unitMultiplier,
+    }: {
+      value: string
+      unitMultiplier: number
+      displayUnitMultiplier?: number
+    }) => {
+      const validatedValue = parseValue({
+        value,
+        maxValue,
+        unitMultiplier,
+        minValue,
+      })
+
+      const validatedDisplayValue = intl.formatNumber(
+        parseDisplayValue({
+          value: validatedValue.toString(),
+          maxValue,
+          unitMultiplier: displayUnitMultiplier,
+        }),
+        { useGrouping: false }
+      )
+
+      const validatedCurrentDisplayValue = intl.formatNumber(
+        parseDisplayValue({
+          value,
+          maxValue,
+          unitMultiplier: 1,
+        }),
+        { useGrouping: false }
+      )
+
+      if (validatedDisplayValue !== validatedCurrentDisplayValue) {
+        showToast(
+          intl.formatMessage(
+            {
+              id: 'store/product-list.quantityUnitMultiplierMismatch',
+            },
+            {
+              unitMultiplier: intl.formatNumber(unitMultiplier),
+              measurementUnit,
+              roundedValue: intl.formatNumber(validatedValue * unitMultiplier),
+            }
+          )
+        )
+      }
+
+      return { validatedValue, validatedDisplayValue }
+    },
+    [intl, maxValue, minValue, measurementUnit, showToast]
+  )
+
+  return [onChange] as const
+}
+
+export default useQuantitySelectorState

--- a/react/components/useQuantitySelectorState.ts
+++ b/react/components/useQuantitySelectorState.ts
@@ -7,7 +7,7 @@ import { parseValue, parseDisplayValue } from './utils'
 const useQuantitySelectorState = ({
   maxValue,
   measurementUnit,
-  minValue = 0,
+  minValue: propMinValue = 0,
 }: {
   maxValue?: number
   minValue?: number
@@ -21,16 +21,26 @@ const useQuantitySelectorState = ({
       value,
       unitMultiplier,
       displayUnitMultiplier = unitMultiplier,
+      minValue = propMinValue,
     }: {
       value: string
       unitMultiplier: number
       displayUnitMultiplier?: number
+      minValue?: number
     }) => {
       const validatedValue = parseValue({
         value,
         maxValue,
         unitMultiplier,
         minValue,
+      })
+
+      const rawParsedValue = parseValue({
+        value,
+        maxValue,
+        unitMultiplier,
+        minValue: 0,
+        round: false,
       })
 
       const validatedDisplayValue = intl.formatNumber(
@@ -42,16 +52,7 @@ const useQuantitySelectorState = ({
         { useGrouping: false }
       )
 
-      const validatedCurrentDisplayValue = intl.formatNumber(
-        parseDisplayValue({
-          value,
-          maxValue,
-          unitMultiplier: 1,
-        }),
-        { useGrouping: false }
-      )
-
-      if (validatedDisplayValue !== validatedCurrentDisplayValue) {
+      if (validatedValue !== rawParsedValue) {
         showToast(
           intl.formatMessage(
             {
@@ -68,7 +69,7 @@ const useQuantitySelectorState = ({
 
       return { validatedValue, validatedDisplayValue }
     },
-    [intl, maxValue, minValue, measurementUnit, showToast]
+    [intl, maxValue, propMinValue, measurementUnit, showToast]
   )
 
   return [onChange] as const

--- a/react/components/utils.ts
+++ b/react/components/utils.ts
@@ -1,7 +1,3 @@
-export const normalizeValue = (value: number, maxValue?: number) => {
-  return maxValue ? Math.min(value, maxValue) : value
-}
-
 export const parseValue = ({
   value,
   maxValue,
@@ -21,13 +17,12 @@ export const parseValue = ({
     return 1
   }
 
-  return normalizeValue(
-    Math.max(
-      (round ? Math.round : (n: number) => n)(parsedValue / unitMultiplier),
-      minValue
-    ),
-    maxValue
+  const roundedValue = Math.max(
+    (round ? Math.round : (n: number) => n)(parsedValue / unitMultiplier),
+    minValue
   )
+
+  return Math.min(roundedValue, maxValue ?? roundedValue)
 }
 
 export const parseDisplayValue = ({
@@ -45,7 +40,5 @@ export const parseDisplayValue = ({
     return unitMultiplier
   }
 
-  const normalizedValue = normalizeValue(parsedValue, maxValue) * unitMultiplier
-
-  return normalizedValue
+  return Math.min(parsedValue, maxValue ?? parsedValue) * unitMultiplier
 }

--- a/react/components/utils.ts
+++ b/react/components/utils.ts
@@ -7,11 +7,13 @@ export const parseValue = ({
   maxValue,
   minValue,
   unitMultiplier,
+  round = true,
 }: {
   value: string
   maxValue?: number
   minValue: number
   unitMultiplier: number
+  round?: boolean
 }) => {
   const parsedValue = parseFloat(value.replace(',', '.'))
 
@@ -20,7 +22,10 @@ export const parseValue = ({
   }
 
   return normalizeValue(
-    Math.max(Math.round(parsedValue / unitMultiplier), minValue),
+    Math.max(
+      (round ? Math.round : (n: number) => n)(parsedValue / unitMultiplier),
+      minValue
+    ),
     maxValue
   )
 }
@@ -37,7 +42,7 @@ export const parseDisplayValue = ({
   const parsedValue = parseFloat(value.replace(',', '.'))
 
   if (Number.isNaN(parsedValue) || parsedValue < 0) {
-    return 1
+    return unitMultiplier
   }
 
   const normalizedValue = normalizeValue(parsedValue, maxValue) * unitMultiplier

--- a/react/components/utils.ts
+++ b/react/components/utils.ts
@@ -1,0 +1,46 @@
+export const normalizeValue = (value: number, maxValue?: number) => {
+  return maxValue ? Math.min(value, maxValue) : value
+}
+
+export const parseValue = ({
+  value,
+  maxValue,
+  minValue,
+  unitMultiplier,
+}: {
+  value: string
+  maxValue?: number
+  minValue: number
+  unitMultiplier: number
+}) => {
+  const parsedValue = parseFloat(value.replace(',', '.'))
+
+  if (Number.isNaN(parsedValue)) {
+    return 1
+  }
+
+  return normalizeValue(
+    Math.max(Math.round(parsedValue / unitMultiplier), minValue),
+    maxValue
+  )
+}
+
+export const parseDisplayValue = ({
+  value,
+  maxValue,
+  unitMultiplier,
+}: {
+  value: string
+  maxValue?: number
+  unitMultiplier: number
+}) => {
+  const parsedValue = parseFloat(value.replace(',', '.'))
+
+  if (Number.isNaN(parsedValue) || parsedValue < 0) {
+    return 1
+  }
+
+  const normalizedValue = normalizeValue(parsedValue, maxValue) * unitMultiplier
+
+  return normalizedValue
+}

--- a/react/styles.css
+++ b/react/styles.css
@@ -21,3 +21,7 @@
 .unitPrice {
   max-width: 100%;
 }
+
+.quantityStepper {
+  max-width: none;
+}


### PR DESCRIPTION
#### What problem is this solving?

Adds the quantity stepper component and the prop `mode` to `quantity-selector` block to toggle between the current input and the quantity stepper.

#### How to test it?

[Workspace](https://stepper--checkoutio.myvtex.com/cart/add?sku=354&qty=1&seller=1&sku=353&qty=1&seller=1).

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/10223856/101389911-dd151000-38a0-11eb-88bf-38a3718be722.png)

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A
