### PR TITLE
Fix item not removed when changing quantity to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Item not being removed when changing quantity to zero in dropdown.
 
 ## [0.27.0] - 2020-12-10
 ### Added

--- a/react/components/QuantitySelector.tsx
+++ b/react/components/QuantitySelector.tsx
@@ -137,6 +137,7 @@ const QuantitySelector: FC<Props> = ({
       value: inputValue,
       unitMultiplier: 1,
       displayUnitMultiplier: unitMultiplier,
+      minValue: 0,
     })
 
     if (validatedValue >= MAX_DROPDOWN_VALUE) {

--- a/react/components/__tests__/QuantitySelector.test.tsx
+++ b/react/components/__tests__/QuantitySelector.test.tsx
@@ -233,4 +233,24 @@ describe('<QuantitySelector />', () => {
 
     expect(showToast).toHaveBeenCalled()
   })
+
+  it('should remove item when changing quantity in dropdown to 0', () => {
+    const onChange = jest.fn()
+    const showToast = jest.fn()
+
+    render(
+      <ToastContext.Provider
+        value={{ showToast, hideToast: jest.fn(), toastState: {} }}
+      >
+        <QuantitySelector id="1" value={1} maxValue={50} onChange={onChange} />
+      </ToastContext.Provider>
+    )
+
+    const [input] = screen.getAllByRole('combobox')
+
+    fireEvent.change(input, { target: { value: '0' } })
+
+    expect(showToast).not.toHaveBeenCalled()
+    expect(onChange).toHaveBeenCalledWith(0)
+  })
 })


### PR DESCRIPTION
#### What problem is this solving?

When changing the item's quantity to zero using the dropdown version of the quantity-selector, the item wasn't being removed and a message was being displayed saying the item's quantity was rounded to 1.

#### How to test it?

[Workspace](https://unitm--checkoutio.myvtex.com/cart/add?sku=289).

Try removing the item using the quantity selector.

#### Screenshots or example usage:

N/A

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/eP1fobjusSbu/giphy.gif)
