### PR TITLE
added labels tag to style the sku specification texts in a better way

### DIFF
--- a/react/ProductVariations.tsx
+++ b/react/ProductVariations.tsx
@@ -9,6 +9,9 @@ import { opaque } from './utils/opaque'
 const CSS_HANDLES = [
   'productVariationsContainer',
   'productVariationsItem',
+  'productVariationItem__labels',
+  'productVariationItem__labels_sku_specification',
+  'productVariationItem__labels_sku_name'
 ] as const
 
 const ProductVariations: FunctionComponent = () => {
@@ -28,7 +31,7 @@ const ProductVariations: FunctionComponent = () => {
             id={`specification-${item.id}-${spec.fieldName}`}
             key={spec.fieldName || undefined}
           >
-            {`${spec.fieldName}: ${spec.fieldValues.join(', ')}`}
+            <div className={handles.productVariationItem__labels}><label className={handles.productVariationItem__labels_sku_specification}>{`${spec.fieldName}`}</label>: <label className={handles.productVariationItem__labels_sku_name}>{`${spec.fieldValues.join(', ')}`}</label></div>
           </div>
         )
       })}


### PR DESCRIPTION
#### What problem is this solving?

Adding new labels tag to separate the name of specification field and its value, solves a styling problem (that today we can't style each in a separate way, because it's a tag with full text/value) - for some stores UX they need more styling in this part

<!--- What is the motivation and context for this change? -->
a better Styling (css code)

#### How to test it?
Just link it in any workspace
