### PR TITLE
Fix link in product image component without rootPath

### DIFF
--- a/.github/workflows/test-react.yml
+++ b/.github/workflows/test-react.yml
@@ -3,7 +3,7 @@ name: Test CI
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   test-react:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Product image component without rootPath in the URL
 
 ## [0.28.1] - 2021-02-22
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-list",
-  "version": "0.28.1",
+  "version": "0.28.2-beta.0",
   "title": "Product List",
   "description": "Product List",
   "defaultLocale": "pt-BR",

--- a/react/Image.tsx
+++ b/react/Image.tsx
@@ -1,6 +1,6 @@
 import type { FunctionComponent } from 'react'
 import React from 'react'
-import { Loading } from 'vtex.render-runtime'
+import { Loading, useRuntime } from 'vtex.render-runtime'
 import type { Item } from 'vtex.checkout-graphql'
 import { useCssHandles } from 'vtex.css-handles'
 
@@ -41,6 +41,7 @@ interface ImageProps {
 const Image: FunctionComponent<ImageProps> = ({ width = 96 }) => {
   const { item, loading } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
+  const { rootPath = '' } = useRuntime()
 
   if (loading) {
     return <Loading />
@@ -58,7 +59,7 @@ const Image: FunctionComponent<ImageProps> = ({ width = 96 }) => {
     >
       <a
         className={handles.productImageAnchor}
-        href={item.detailUrl || undefined}
+        href={item.detailUrl ? rootPath + item.detailUrl : undefined}
       >
         {imageUrl ? (
           <img

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -16,20 +16,21 @@ type TotalItemsType =
   | 'distinctAvailable'
 
 interface Props {
-  allowManualPrice: boolean
+  allowManualPrice?: boolean
   items: ItemWithIndex[]
   loading: boolean
-  userType: string
-  itemCountMode: TotalItemsType
+  userType?: string
+  itemCountMode?: TotalItemsType
   onQuantityChange: (
     uniqueId: string,
     value: number,
     item?: ItemWithIndex
   ) => void
   onRemove: (uniqueId: string, item?: ItemWithIndex) => void
-  onSetManualPrice: (price: number, itemIndex: number) => void
+  onSetManualPrice?: (price: number, itemIndex: number) => void
   lazyRenderHeight?: number
   lazyRenderOffset?: number
+  children: ReactNode
 }
 
 interface ItemWithIndex extends Item {
@@ -49,7 +50,7 @@ interface ItemWrapperProps
   loading: boolean
   children: ReactNode
   shouldAllowManualPrice: boolean
-  onSetManualPrice: (price: number, itemIndex: number) => void
+  onSetManualPrice?: (price: number, itemIndex: number) => void
   lazyRenderHeight?: number
   lazyRenderOffset?: number
 }
@@ -76,7 +77,7 @@ const ItemContextWrapper = memo<ItemWrapperProps>(function ItemContextWrapper({
         onQuantityChange(item.uniqueId, value, item),
       onRemove: () => onRemove(item.uniqueId, item),
       onSetManualPrice: (price: number, index: number) =>
-        onSetManualPrice(price, index),
+        onSetManualPrice?.(price, index),
     }),
     [
       item,
@@ -127,13 +128,19 @@ const countCartItems = (countMode: TotalItemsType, arr: Item[]) => {
   return arr.length
 }
 
-const ProductList: React.FC<Props> = (props) => {
+const ProductList = memo<Props>(function ProductList(props) {
   const {
     items,
-    itemCountMode,
+    itemCountMode = 'distinct',
     lazyRenderHeight = 100,
     lazyRenderOffset = 300,
+    userType = 'STORE_USER',
+    allowManualPrice = false,
+    children,
   } = props
+
+  const shouldAllowManualPrice =
+    allowManualPrice && userType === CALL_CENTER_OPERATOR
 
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -165,10 +172,6 @@ const ProductList: React.FC<Props> = (props) => {
         </div>
       ) : null}
       {unavailableItems.map((item) => {
-        const { userType, allowManualPrice, children } = props
-        const shouldAllowManualPrice =
-          allowManualPrice && userType === CALL_CENTER_OPERATOR
-
         return (
           <ItemContextWrapper
             key={`${item.uniqueId}-${item.sellingPrice}`}
@@ -196,10 +199,6 @@ const ProductList: React.FC<Props> = (props) => {
         </div>
       ) : null}
       {availableItems.map((item) => {
-        const { userType, allowManualPrice, children } = props
-        const shouldAllowManualPrice =
-          allowManualPrice && userType === CALL_CENTER_OPERATOR
-
         return (
           <ItemContextWrapper
             key={`${item.uniqueId}-${item.sellingPrice}`}
@@ -216,6 +215,6 @@ const ProductList: React.FC<Props> = (props) => {
       })}
     </div>
   )
-}
+})
 
-export default memo(ProductList)
+export default ProductList

--- a/react/__mocks__/vtex.render-runtime.tsx
+++ b/react/__mocks__/vtex.render-runtime.tsx
@@ -1,9 +1,8 @@
 import type { FunctionComponent } from 'react'
-import React, { useState } from 'react'
+import React from 'react'
 
 export const Loading: FunctionComponent = () => <div />
 
-export const useRuntime = () => {
-  const [rootPath, setRootPath] = useState('')
-  return { rootPath }
-}
+export const useRuntime = jest.fn(() => ({
+  rootPath: '',
+}))

--- a/react/__tests__/ProductList.test.tsx
+++ b/react/__tests__/ProductList.test.tsx
@@ -1,6 +1,7 @@
 import type { FunctionComponent } from 'react'
 import React from 'react'
-import { render, fireEvent } from '@vtex/test-tools/react'
+import { render, fireEvent, screen } from '@vtex/test-tools/react'
+import { useRuntime } from 'vtex.render-runtime'
 
 import { items } from '../__fixtures__/items'
 import AvailabilityMessage from '../AvailabilityMessage'
@@ -116,5 +117,53 @@ describe('Product List', () => {
     )
 
     expect(queryByText(/cannot be delivered/)).toBeTruthy()
+  })
+
+  it('should render the product detailUrl with correct rootPath', () => {
+    const { unmount } = render(
+      <ProductList
+        items={[items[0]]}
+        loading={false}
+        onQuantityChange={() => {}}
+        onRemove={() => {}}
+      >
+        <ListItem />
+      </ProductList>
+    )
+
+    let [productImageLink, productNameLink] = screen.getAllByRole('link')
+
+    expect(productImageLink).toHaveAttribute('href', '/work-shirt/p')
+    expect(productImageLink).toHaveClass('productImageAnchor')
+    expect(productNameLink).toHaveAttribute('href', '/work-shirt/p')
+    expect(productNameLink).toHaveClass('productName')
+
+    const mockedUseRuntime = useRuntime as jest.MockedFunction<
+      () => ReturnType<typeof useRuntime>
+    >
+
+    // @ts-expect-error: we are not mocking everything on purpose
+    mockedUseRuntime.mockReturnValue({
+      rootPath: '/pt-br',
+    })
+
+    unmount()
+
+    render(
+      <ProductList
+        items={[items[0]]}
+        loading={false}
+        onQuantityChange={() => {}}
+        onRemove={() => {}}
+      >
+        <ListItem />
+      </ProductList>
+    )
+    ;[productImageLink, productNameLink] = screen.getAllByRole('link')
+
+    expect(productImageLink).toHaveAttribute('href', '/pt-br/work-shirt/p')
+    expect(productImageLink).toHaveClass('productImageAnchor')
+    expect(productNameLink).toHaveAttribute('href', '/pt-br/work-shirt/p')
+    expect(productNameLink).toHaveClass('productName')
   })
 })

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1486,9 +1486,9 @@
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
 "@types/node@^11.13.0":
-  version "11.15.39"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.39.tgz#00043d22cb2814c0ca32ef17e789911aa2325d9a"
-  integrity sha512-vVNBFg0n7vd2GuIEDa/s854RpcqAMRer/8IPmhKCYEoC2cLDGeTPNwlnAmSoI0sddOPhTb82DDWeHMrqEi5p3w==
+  version "11.15.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.47.tgz#c3696f1e31c70dd282b4c3b4a7dc3d5b9ba076e9"
+  integrity sha512-S4vrkrslntCM+1cw9Q27M/doWQrZklb9lOyo4b+K27SOo5jZYEKY5epdixySx7OI+A67DMJ8W/XBiLMBiI452A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1525,7 +1525,15 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/react@^16.8.10", "@types/react@^16.9.44":
+"@types/react@^16.8.10":
+  version "16.14.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.4.tgz#365f6a1e117d1eec960ba792c7e1e91ecad38e6f"
+  integrity sha512-ETj7GbkPGjca/A4trkVeGvoIakmLV6ZtX3J8dcmOpzKzWVybbrOxanwaIPG71GZwImoMDY6Fq4wIe34lEqZ0FQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16.9.44":
   version "16.14.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
   integrity sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==
@@ -2434,9 +2442,9 @@ csstype@^2.5.2:
   integrity sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A==
 
 csstype@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
-  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
+  integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
#### What problem is this solving?

Fixes the link in the product image component for stores that use the rootPath feature.

#### How to test it?

[Workspace](https://www.mujionline.eu/uk/?workspace=rootpprod)

Add some product to your cart and then check the link of the product image in minicart. It should contain the current binding you are seeing the store in.

If you encounter some errors when visiting the link above for the first time, it is completely normal since we are using a dev workspace in a prod cluster, so the pods in our infra can take a while to start and cause some timeouts/errors.

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

N/A

#### Related to / Depends on

N/A
