### PR TITLE
Add prop "quantitySelectorStep" to "quantity-selector" block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.29.1] - 2021-05-31
 ### Added
-- Prop `showBultAsUnit` to `quantity-selector` block.
+- Prop `quantitySelectorStep` to `quantity-selector` block.
 
 ## [0.29.0] - 2021-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.29.1] - 2021-05-31
+### Added
+- Prop `showBultAsUnit` to `quantity-selector` block.
+
 ## [0.29.0] - 2021-04-26
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,7 +320,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
-| `quantitySelectorStep` | `enum` | Defines how quantity of products that have unitMultiplier will show. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
+| `quantitySelectorStep` | `enum` | Defines how the number of products that have unitMultiplier will show. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,7 +320,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
-| `quantitySelectorStep` | `enum` | Defines how the number of products that have unitMultiplier will show. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
+| `quantitySelectorStep` | `enum` | Defines how the number of products that have unitMultiplier will works. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,7 +320,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
-| `quantitySelectorStep` | `enum` | Show as unit the quantity of products, this is usefull in the case that the product have unitMultiplier. Possible values are `singleUnit` and `unitMultiplier`. On the `unitMultiplier`, the quantity will be affected with the unitMultiplier. On the `singleUnit`, the quantity will be not affected with the unitMultiplier.| `unitMultiplier`    |
+| `quantitySelectorStep` | `enum` | Defines how quantity of products that have unitMultiplier will show. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,6 +320,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
+| `showBultAsUnit` | `boolean` | Show as unit the quantity of products, this is usefull in the case that the product have unitMultiplier. Possible values are `true` and `false`. On the false showBultAsUnit, the quantity will be affected with the unitMultiplier. On the true showBultAsUnit, the quantity will be not affected with the unitMultiplier.| `false`    |
 
 ## Customization
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -320,7 +320,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | Prop name | Type | Description | Default value |
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
-| `showBultAsUnit` | `boolean` | Show as unit the quantity of products, this is usefull in the case that the product have unitMultiplier. Possible values are `true` and `false`. On the false showBultAsUnit, the quantity will be affected with the unitMultiplier. On the true showBultAsUnit, the quantity will be not affected with the unitMultiplier.| `false`    |
+| `quantitySelectorStep` | `enum` | Show as unit the quantity of products, this is usefull in the case that the product have unitMultiplier. Possible values are `singleUnit` and `unitMultiplier`. On the `unitMultiplier`, the quantity will be affected with the unitMultiplier. On the `singleUnit`, the quantity will be not affected with the unitMultiplier.| `unitMultiplier`    |
 
 ## Customization
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-list",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "title": "Product List",
   "description": "Product List",
   "defaultLocale": "pt-BR",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "product-list",
-  "version": "0.29.1",
+  "version": "0.29.0",
   "title": "Product List",
   "description": "Product List",
   "defaultLocale": "pt-BR",

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -27,12 +27,11 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default', showBultAsUnit = false
   if (loading) {
     return <Loading />
   }
-
+  let unitMultiplier = item.unitMultiplier ?? undefined
+  if (showBultAsUnit){
+    unitMultiplier = 1
+  }
   if (mode === 'stepper') {
-    let unitMultiplier = item.unitMultiplier ?? undefined
-    if (showBultAsUnit){
-      unitMultiplier = 1
-    }
     return (
       <div
         className={classnames(
@@ -70,7 +69,7 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default', showBultAsUnit = false
         maxValue={MAX_ITEM_QUANTITY}
         onChange={onQuantityChange}
         disabled={item.availability !== AVAILABLE}
-        unitMultiplier={item.unitMultiplier ?? undefined}
+        unitMultiplier={unitMultiplier}
         measurementUnit={item.measurementUnit ?? undefined}
       />
     </div>

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -29,10 +29,7 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep =
   if (loading) {
     return <Loading />
   }
-  let unitMultiplier = item.unitMultiplier ?? undefined
-  if (quantitySelectorStep === 'singleUnit') {
-    unitMultiplier = 1
-  }
+  const unitMultiplier = quantitySelectorStep === 'singleUnit' ? 1 : item.unitMultiplier
   if (mode === 'stepper') {
     return (
       <div

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -15,20 +15,21 @@ const MAX_ITEM_QUANTITY = 99999
 const CSS_HANDLES = ['quantitySelectorContainer'] as const
 
 type QuantitySelectorMode = 'default' | 'stepper'
+export type QuantitySelectorStepType = 'unitMultiplier' | 'singleUnit'
 
 interface Props {
   mode?: QuantitySelectorMode
-  showBultAsUnit?: boolean
+  quantitySelectorStep?: QuantitySelectorStepType
 }
 
-const QuantitySelector: VFC<Props> = ({ mode = 'default', showBultAsUnit = false }) => {
+const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep = 'unitMultiplier' }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
   if (loading) {
     return <Loading />
   }
   let unitMultiplier = item.unitMultiplier ?? undefined
-  if (showBultAsUnit){
+  if (quantitySelectorStep === 'singleUnit') {
     unitMultiplier = 1
   }
   if (mode === 'stepper') {

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -18,17 +18,22 @@ type QuantitySelectorMode = 'default' | 'stepper'
 
 interface Props {
   mode?: QuantitySelectorMode
+  showBultAsUnit?: boolean
 }
 
-const QuantitySelector: VFC<Props> = ({ mode = 'default' }) => {
+const QuantitySelector: VFC<Props> = ({ mode = 'default', showBultAsUnit = false }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
-
+  console.log("item on QuantitySelector", item)
   if (loading) {
     return <Loading />
   }
 
   if (mode === 'stepper') {
+    let unitMultiplier = item.unitMultiplier ?? undefined
+    if (showBultAsUnit){
+      unitMultiplier = 1
+    }
     return (
       <div
         className={classnames(
@@ -44,7 +49,7 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default' }) => {
           maxValue={MAX_ITEM_QUANTITY}
           onChange={onQuantityChange}
           disabled={item.availability !== AVAILABLE}
-          unitMultiplier={item.unitMultiplier ?? undefined}
+          unitMultiplier={unitMultiplier}
           measurementUnit={item.measurementUnit ?? undefined}
         />
       </div>

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -25,6 +25,7 @@ interface Props {
 const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep = 'unitMultiplier' }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
+  
   if (loading) {
     return <Loading />
   }

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -29,7 +29,7 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep =
   if (loading) {
     return <Loading />
   }
-  const unitMultiplier = quantitySelectorStep === 'singleUnit' ? 1 : item.unitMultiplier
+  const unitMultiplier = quantitySelectorStep === 'singleUnit' ? 1 : item.unitMultiplier ?? undefined
   if (mode === 'stepper') {
     return (
       <div

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -24,7 +24,6 @@ interface Props {
 const QuantitySelector: VFC<Props> = ({ mode = 'default', showBultAsUnit = false }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
-  console.log("item on QuantitySelector", item)
   if (loading) {
     return <Loading />
   }


### PR DESCRIPTION
#### What problem is this solving?
When the product have unitMultiplier, if you add more items, the quantity will be affected with the unitMultiplier.
With this prop the quantity will be not affected with the unitMultiplier.
This was required for a client who want to show in the minicart the quantity of products that have unitMultiplier as units.

#### How to test it?
Changed the product quantity on minicart
<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace] https://fpatest01--arvitalb2bqa.myvtex.com/

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->
![Grabación de pantalla 2021-05-28 a la(s) 10 25 43](https://user-images.githubusercontent.com/55905671/119991594-ff5e2f80-bf9f-11eb-9a90-1336e51a00e2.gif)

#### Describe alternatives you've considered, if any.
Use the product-quantity on minicart.

