### PR TITLE
Fix showListPrice prop on price block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `showListPrice` prop on `price` block
 
 ## [0.29.0] - 2021-04-26
 

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -37,7 +37,7 @@ const Price: React.FC<PriceProps> = ({
         handles.productPriceContainer
       } ${parseTextAlign(textAlign)}`}
     >
-      {item.listPrice && item.listPrice !== item.price && showListPrice && (
+      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice && (
         <div
           id={`list-price-${item.id}`}
           className={`${handles.productPriceCurrency} c-muted-1 strike t-mini mb2`}


### PR DESCRIPTION
#### What problem is this solving?
The `showListPrice` props did not work properly. Even if the sellingPrice was lower than the listPrice, the listPrice was never displayed.

Example:
- price: 2857
- listPrice: 2857
- sellingPrice: 2571

The condition checks if the price and the listPrice are different, and in this case is not.

#### How to test it?

[Workspace](https://longo--diverta.myvtex.com/harlequin--yra02081/p


#### Screenshots or example usage:
![price](https://user-images.githubusercontent.com/43498488/122527559-15519400-d024-11eb-8444-c33b4a5fda38.jpg)
)