### PR TITLE
Add New CSS Handles in QuantityStepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.30.0] - 2021-07-20
+
+### Added
+- CSS Handles in QuantityStepper
+
 ## [0.29.0] - 2021-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.30.0] - 2021-07-20
-
 ### Added
 - CSS Handles in QuantityStepper
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,7 +352,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `quantityInputContainer`             |
 | `quantityInputMobileContainer`       |
 | `quantitySelectorContainer`          |
-| `quantitySelectorWrap`               |
+| `quantitySelectorWrapper`               |
 | `quantitySelectorButton`             |
 | `quantitySelectorDecrease`           |
 | `quantitySelectorIncrease`           |

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,7 +352,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `quantityInputContainer`             |
 | `quantityInputMobileContainer`       |
 | `quantitySelectorContainer`          |
-| `quantitySelectorWrapper`               |
+| `quantitySelectorWrapper`            |
 | `quantitySelectorButton`             |
 | `quantitySelectorDecrease`           |
 | `quantitySelectorIncrease`           |

--- a/docs/README.md
+++ b/docs/README.md
@@ -352,6 +352,10 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `quantityInputContainer`             |
 | `quantityInputMobileContainer`       |
 | `quantitySelectorContainer`          |
+| `quantitySelectorWrap`               |
+| `quantitySelectorButton`             |
+| `quantitySelectorDecrease`           |
+| `quantitySelectorIncrease`           |
 | `removeButtonContainer`              |
 | `removeButton`                       |
 | `unitPriceContainer`                 |

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -2,6 +2,7 @@ import type { VFC } from 'react'
 import React, { useState, useEffect } from 'react'
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl'
 import classnames from 'classnames'
+import { useCssHandles } from 'vtex.css-handles'
 
 import VisuallyHidden from './VisuallyHidden'
 import IncreaseIcon from './IncreaseIcon'
@@ -9,6 +10,13 @@ import DecreaseIcon from './DecreaseIcon'
 import { parseDisplayValue } from './utils'
 import useQuantitySelectorState from './useQuantitySelectorState'
 import styles from './QuantityStepper.css'
+
+const CSS_HANDLES = [
+  'quantitySelectorWrap',
+  'quantitySelectorButton',
+  'quantitySelectorDecrease',
+  'quantitySelectorIncrease',
+] as const
 
 const messages = defineMessages({
   increaseQuantity: {
@@ -47,6 +55,8 @@ const QuantityStepper: VFC<Props> = ({
     measurementUnit,
     minValue: 1,
   })
+
+  const handles = useCssHandles(CSS_HANDLES)
 
   const [focused, setFocused] = useState(false)
 
@@ -136,12 +146,15 @@ const QuantityStepper: VFC<Props> = ({
   const uniqueId = id ? `product-list-quantity-stepper-${id}` : undefined
 
   return (
-    <div className="flex">
+    <div className={classnames(handles.quantitySelectorWrap, 'flex')}>
       <button
         className={classnames(
+          handles.quantitySelectorButton,
+          handles.quantitySelectorDecrease,
           'pa4 ba br2 br--left flex items-center justify-center',
           {
-            'c-muted-1 b--muted-4 hover-b--muted-3 bg-muted-5 hover-bg-muted-4 pointer': !disabled,
+            'c-muted-1 b--muted-4 hover-b--muted-3 bg-muted-5 hover-bg-muted-4 pointer':
+              !disabled,
             'bg-muted-5 c-muted-3 b--muted-4': disabled,
           }
         )}
@@ -184,9 +197,12 @@ const QuantityStepper: VFC<Props> = ({
       </div>
       <button
         className={classnames(
+          handles.quantitySelectorButton,
+          handles.quantitySelectorIncrease,
           'pa4 ba br2 br--right flex items-center justify-center',
           {
-            'c-action-primary b--muted-4 hover-b--muted-3 bg-base hover-bg-muted-5 pointer': !disabled,
+            'c-action-primary b--muted-4 hover-b--muted-3 bg-base hover-bg-muted-5 pointer':
+              !disabled,
             'bg-muted-5 c-muted-3 b--muted-4': disabled,
           }
         )}

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -146,7 +146,7 @@ const QuantityStepper: VFC<Props> = ({
   const uniqueId = id ? `product-list-quantity-stepper-${id}` : undefined
 
   return (
-    <div className={classnames(handles.quantitySelectorWrap, 'flex')}>
+    <div className={`flex ${handles.quantitySelectorWrapper}`}>
       <button
         className={classnames(
           handles.quantitySelectorButton,

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -12,7 +12,7 @@ import useQuantitySelectorState from './useQuantitySelectorState'
 import styles from './QuantityStepper.css'
 
 const CSS_HANDLES = [
-  'quantitySelectorWrap',
+  'quantitySelectorWrapper',
   'quantitySelectorButton',
   'quantitySelectorDecrease',
   'quantitySelectorIncrease',


### PR DESCRIPTION
#### What problem is this solving?

Customize the QuantityStepper buttons and input with CSS Handles.

#### How to test it?

[Workspace](https://fabiowill--dentalpartner.myvtex.com/)

#### Screenshots or example usage:

Before:
![Screen Shot 2021-07-12 at 16 25 23](https://user-images.githubusercontent.com/6069644/125344906-4163ea80-e32e-11eb-9997-6dc7568be443.png)

After:
![Screen Shot 2021-07-12 at 16 25 35](https://user-images.githubusercontent.com/6069644/125345268-b6cfbb00-e32e-11eb-9e30-48b6d2b535dc.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![https://giphy.com/gifs/memecandy-LmNwrBhejkK9EFP504]