### PR TITLE
Fixed listPrice condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.30.0] - 2021-07-27
+
+### Fixed
+- Changed conditon to properly compare item `listPrice` with `sellingPrice` instead of `price`.
+
 ## [0.29.0] - 2021-04-26
 
 ### Added

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -33,11 +33,10 @@ const Price: React.FC<PriceProps> = ({
 
   return (
     <div
-      className={`${opaque(item.availability)} ${styles.price} ${
-        handles.productPriceContainer
-      } ${parseTextAlign(textAlign)}`}
+      className={`${opaque(item.availability)} ${styles.price} ${handles.productPriceContainer
+        } ${parseTextAlign(textAlign)}`}
     >
-      {item.listPrice && item.listPrice !== item.price && showListPrice && (
+      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice && (
         <div
           id={`list-price-${item.id}`}
           className={`${handles.productPriceCurrency} c-muted-1 strike t-mini mb2`}


### PR DESCRIPTION
#### What problem is this solving?

In some particular cases, the `price` and `sellingPrice` are different. But this scenario wasn't being covered.

![image](https://user-images.githubusercontent.com/7140358/127246643-60bd533f-48ff-4dd5-8573-e51f5c039dc0.png)

This fix simply changed that by replacing `price` for `sellingPrice` in Price conditional allowing `listPrice` to be displayed.

#### How to test it?

[Workspace](https://frnqa2--taafrl.myvtex.com/vinho-yamana-sweet-red-750ml/p)

Just add the aforementioned product to cart, and compare with some product using `price` old attribute

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/7140358/127246761-617adcbb-4a5a-4f9e-bd80-9b3d0bf028b7.png)

#### Related to / Depends on

[Fix showListPrice prop on price block #106](https://github.com/vtex-apps/product-list/pull/106)

It's solving this same problem.

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/rIq6ASPIqo2k0/giphy.gif)
