### PR TITLE
Compare listPrice to sellingPrice to properly show the discount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- item.price changed to item.sellingPrice in Price.tsx component conditional
+- List price is now displayed when discount is applied by a promotion
 
 ## [0.32.0] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- item.price changed to item.sellingPrice in Price.tsx component conditional
+
 ## [0.32.0] - 2021-09-29
 
 ### Added

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -37,7 +37,7 @@ const Price: React.FC<PriceProps> = ({
         handles.productPriceContainer
       } ${parseTextAlign(textAlign)}`}
     >
-      {item.listPrice && item.listPrice !== item.price && showListPrice && (
+      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice && (
         <div
           id={`list-price-${item.id}`}
           className={`${handles.productPriceCurrency} c-muted-1 strike t-mini mb2`}


### PR DESCRIPTION

#### What problem is this solving?

If the product's discount doesn't come from Catalog's List Price, but from other source like a promotion, its listPrice and price are the same, and the listPrice isn't displayed, even though the product has a discount to be displayed.

#### How to test it?

Add the product to cart and check minicart. Even though the sellingPrice has a discount, no listPrice is shown.
![image](https://user-images.githubusercontent.com/59453854/134412878-06f1673d-d599-4bef-a60c-2c65b233bf87.png)

[Workspace]https://storetheme--brunovaletta.myvtex.com/whisky-johnnie-walker-red-label-1l/p


After the changes, its listPrice is shown in minicart:
![image](https://user-images.githubusercontent.com/59453854/134413392-301319ad-5986-46b7-8a4b-f99c42e2a4f5.png)

[Workspace]https://fixpricelist--brunovaletta.myvtex.com/whisky-johnnie-walker-red-label-1l/p


#### How does this PR make you feel? 

![](https://media.giphy.com/media/XdUMiySExIdwvsPOpP/giphy.gif)
