### PR TITLE
Fixing QuantitySelector disabled rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `QuantitySelector` is no longer disabled when items are unavailable because they cannot be delivered. This allow users to change the quantity of the item back to when it didn't exceed the maximum weight chosen for deliveries.
 
 ## [0.34.0] - 2022-01-12
 ### Added

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -7,7 +7,7 @@ import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 import Selector from './components/QuantitySelector'
 import QuantityStepper from './components/QuantityStepper'
 import { useItemContext } from './ItemContext'
-import { AVAILABLE } from './constants/Availability'
+import { AVAILABLE, CANNOT_BE_DELIVERED } from './constants/Availability'
 import { opaque } from './utils/opaque'
 import styles from './styles.css'
 
@@ -22,31 +22,49 @@ interface Props {
   quantitySelectorStep?: QuantitySelectorStepType
 }
 
-const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep = 'unitMultiplier' }) => {
+const enabledSelectorAvailability = [AVAILABLE, CANNOT_BE_DELIVERED]
+
+function shouldDisableSelector(availability: string | null | undefined) {
+  return !enabledSelectorAvailability.includes(availability ?? '')
+}
+
+const QuantitySelector: VFC<Props> = ({
+  mode = 'default',
+  quantitySelectorStep = 'unitMultiplier',
+}) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
 
   if (loading) {
     return <Loading />
   }
-  const unitMultiplier = quantitySelectorStep === 'singleUnit' ? 1 : item.unitMultiplier ?? undefined
+
+  const unitMultiplier =
+    quantitySelectorStep === 'singleUnit' ? 1 : item.unitMultiplier ?? undefined
+
   if (mode === 'stepper') {
     return (
       <div
-        className={classnames(
-          opaque(item.availability),
-          handles.quantitySelectorContainer,
-          styles.quantity,
-          styles.quantityStepper
-        ) + applyModifiers(styles.quantitySelector, item.sellingPrice === 0 ? "gift" : "")}
+        className={
+          classnames(
+            opaque(item.availability),
+            handles.quantitySelectorContainer,
+            styles.quantity,
+            styles.quantityStepper
+          ) +
+          applyModifiers(
+            styles.quantitySelector,
+            item.sellingPrice === 0 ? 'gift' : ''
+          )
+        }
       >
         <QuantityStepper
           id={item.id}
           value={item.quantity}
           maxValue={MAX_ITEM_QUANTITY}
           onChange={onQuantityChange}
-          disabled={item.availability !== AVAILABLE}
           unitMultiplier={unitMultiplier}
+          disabled={shouldDisableSelector(item.availability)}
           measurementUnit={item.measurementUnit ?? undefined}
         />
       </div>
@@ -55,19 +73,25 @@ const QuantitySelector: VFC<Props> = ({ mode = 'default', quantitySelectorStep =
 
   return (
     <div
-      className={classnames(
-        opaque(item.availability),
-        handles.quantitySelectorContainer,
-        styles.quantity,
-        styles.quantitySelector
-      ) + applyModifiers(styles.quantitySelector, item.sellingPrice === 0 ? "gift" : "")}
+      className={
+        classnames(
+          opaque(item.availability),
+          handles.quantitySelectorContainer,
+          styles.quantity,
+          styles.quantitySelector
+        ) +
+        applyModifiers(
+          styles.quantitySelector,
+          item.sellingPrice === 0 ? 'gift' : ''
+        )
+      }
     >
       <Selector
         id={item.id}
         value={item.quantity}
         maxValue={MAX_ITEM_QUANTITY}
         onChange={onQuantityChange}
-        disabled={item.availability !== AVAILABLE}
+        disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}
         measurementUnit={item.measurementUnit ?? undefined}
       />


### PR DESCRIPTION
#### What problem is this solving?

This PR solves this problem: https://vtex.slack.com/archives/C01PRGM0WG1/p1642631185007500. Essentially, it allow users to change the quantity of the product event if that product cannot be delivered to their address.

#### How to test it?

Add products and increase their quantity. You should be able to lower the quantity even if there's a warning saying the items cannot be delivered. Use the address: Avenida Paseo de la Reforma, 500.

[Workspace](https://icarovtex--modeloramanow.myvtex.com/inicio)

#### Screenshots or example usage:
![Screen Shot 2022-01-20 at 18 10 15](https://user-images.githubusercontent.com/8127610/150422619-ff60f01c-2600-4622-920d-f7cce4aede27.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xULW8EUPyXTtsbq63e/giphy.gif)
