### PR TITLE
Show un

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `QuantitySelector` and `QuantityStepper` modified so that in the mini cart and also in the product list it displays the unit of measure UN
+
 ## [0.34.1] - 2022-01-24
 ### Fixed
 - `QuantitySelector` is no longer disabled when items are unavailable because they cannot be delivered. This allow users to change the quantity of the item back to when it didn't exceed the maximum weight chosen for deliveries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -321,6 +321,7 @@ Therefore, in order to customize the `product-list` configuration, you can simpl
 | --- | --- | --- | --- |
 | `mode` | `enum` | Mode of the quantity selector input. Possible values are `default` and `stepper`. On the default mode, the quantity stepper will initially render a dropdown component, and after the quantity exceeds 10, it will switch to an input. In the stepper mode it will always render a numeric stepper component. | `default`    |
 | `quantitySelectorStep` | `enum` | Defines how the number of products that have unitMultiplier will works. Possible values are: `singleUnit` (the quantity will be not affected with the unitMultiplier) and `unitMultiplier` (the quantity will be affected with the unitMultiplier). | `unitMultiplier` |
+| `displayUn` | `boolean` | Whether the UN unit of measure should be displayed (true) or not (false) | `false` |
 
 ## Customization
 

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -20,6 +20,7 @@ export type QuantitySelectorStepType = 'unitMultiplier' | 'singleUnit'
 interface Props {
   mode?: QuantitySelectorMode
   quantitySelectorStep?: QuantitySelectorStepType
+  displayUn?: boolean
 }
 
 const enabledSelectorAvailability = [AVAILABLE, CANNOT_BE_DELIVERED]
@@ -31,6 +32,7 @@ function shouldDisableSelector(availability: string | null | undefined) {
 const QuantitySelector: VFC<Props> = ({
   mode = 'default',
   quantitySelectorStep = 'unitMultiplier',
+  displayUn = false
 }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
@@ -66,6 +68,7 @@ const QuantitySelector: VFC<Props> = ({
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
           measurementUnit={item.measurementUnit ?? undefined}
+          displayUn={displayUn}
         />
       </div>
     )

--- a/react/components/QuantityStepper.tsx
+++ b/react/components/QuantityStepper.tsx
@@ -35,6 +35,7 @@ interface Props {
   disabled?: boolean
   unitMultiplier?: number
   measurementUnit?: string
+  displayUn?: boolean
 }
 
 const QuantityStepper: VFC<Props> = ({
@@ -45,6 +46,7 @@ const QuantityStepper: VFC<Props> = ({
   disabled,
   unitMultiplier = 1,
   measurementUnit = 'un',
+  displayUn,
 }) => {
   const intl = useIntl()
 
@@ -191,7 +193,7 @@ const QuantityStepper: VFC<Props> = ({
           onFocus={() => setFocused(true)}
           onBlur={handleInputBlur}
         />
-        {measurementUnit !== 'un' && (
+        {(measurementUnit !== 'un' || displayUn) && (
           <span className="c-muted-1 ml3">{measurementUnit}</span>
         )}
       </div>


### PR DESCRIPTION
#### What problem is this solving?

Now we can display the UN measurement unit in case the customer needs it

#### How to test it?

Using the quantity-selector app, add to the "display: True" prop, the UN unit of measure should appear next to the quantity in the mini-cart

[Workspace](https://quantityselector--gigadigital.myvtex.com/)

#### Screenshots or example usage:

[Imagem](https://imgur.com/a/nHTZMzn)

