### PR TITLE
added props for showing sku name or bundle items in the product list

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,8 +2,6 @@
   "extends": "vtex",
   "root": true,
   "env": {
-    "node": true,
-    "es6": true,
-    "jest": true
+    "node": true
   }
 }

--- a/react/ItemContext.tsx
+++ b/react/ItemContext.tsx
@@ -10,6 +10,8 @@ interface Context {
   onQuantityChange: (value: number) => void
   onRemove: () => void
   onSetManualPrice: (price: number, itemIndex: number) => void
+  showSku: boolean
+  showBundles: boolean
 }
 
 interface ItemContextProviderProps {

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -24,7 +24,8 @@ const Price: React.FC<PriceProps> = ({
   textAlign = 'left',
   showListPrice = true,
 }) => {
-  const { item, loading } = useItemContext()
+  const { item, loading, showBundles } = useItemContext()
+  const hasBundles = item.bundleItems.length > 0
   const handles = useCssHandles(CSS_HANDLES)
 
   if (loading) {
@@ -32,36 +33,65 @@ const Price: React.FC<PriceProps> = ({
   }
 
   return (
-    <div
-      className={`${opaque(item.availability)} ${styles.price} ${
-        handles.productPriceContainer
-      } ${parseTextAlign(textAlign)}`}
-    >
-      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice && (
+    <div>
+      <div
+        className={`${opaque(item.availability)} ${styles.price} ${
+          handles.productPriceContainer
+        } ${parseTextAlign(textAlign)}`}
+      >
+        {item.listPrice &&
+          item.listPrice !== item.sellingPrice &&
+          showListPrice && (
+            <div
+              id={`list-price-${item.id}`}
+              className={`${handles.productPriceCurrency}  ${applyModifiers(
+                handles.productPriceCurrency,
+                item.sellingPrice === 0 ? 'gift' : ''
+              )} c-muted-1 strike t-mini mb2`}
+            >
+              <FormattedCurrency
+                value={
+                  (item.listPrice *
+                    (item.unitMultiplier || 1) *
+                    item.quantity) /
+                  100
+                }
+              />
+            </div>
+          )}
         <div
-          id={`list-price-${item.id}`}
-          className={`${handles.productPriceCurrency}  ${applyModifiers(handles.productPriceCurrency, item.sellingPrice === 0 ? "gift" : "")} c-muted-1 strike t-mini mb2`}
+          id={`price-${item.id}`}
+          className={`${handles.productPrice} ${applyModifiers(
+            handles.productPrice,
+            item.sellingPrice === 0 ? 'gift' : ''
+          )} div fw6 fw5-m`}
         >
-          <FormattedCurrency
+          <FormattedPrice
             value={
-              (item.listPrice * (item.unitMultiplier || 1) * item.quantity) /
-              100
+              item.sellingPrice != null
+                ? (item.sellingPrice * item.quantity) / 100
+                : item.sellingPrice
             }
           />
         </div>
-      )}
-      <div
-        id={`price-${item.id}`}
-        className={`${handles.productPrice} ${applyModifiers(handles.productPrice, item.sellingPrice === 0 ? "gift" : "")} div fw6 fw5-m`}
-      >
-        <FormattedPrice
-          value={
-            item.sellingPrice != null
-              ? (item.sellingPrice * item.quantity) / 100
-              : item.sellingPrice
-          }
-        />
       </div>
+      {showBundles &&
+        hasBundles &&
+        item.bundleItems.map((bundle, key) => {
+          return (
+            <p key={key}>
+              {bundle.name}:{` `}
+              <FormattedCurrency
+                value={
+                  (Number(bundle.sellingPrice) *
+                    (bundle.unitMultiplier || 1) *
+                    bundle.quantity) /
+                  100
+                }
+              />
+            </p>
+          )
+        })}
     </div>
   )
 }

--- a/react/ProductList.tsx
+++ b/react/ProductList.tsx
@@ -31,6 +31,8 @@ interface Props {
   lazyRenderHeight?: number
   lazyRenderOffset?: number
   children: ReactNode
+  showSku: boolean
+  showBundles: boolean
 }
 
 interface ItemWithIndex extends Item {
@@ -53,6 +55,8 @@ interface ItemWrapperProps
   onSetManualPrice?: (price: number, itemIndex: number) => void
   lazyRenderHeight?: number
   lazyRenderOffset?: number
+  showSku: boolean
+  showBundles: boolean
 }
 
 const ItemContextWrapper = memo<ItemWrapperProps>(function ItemContextWrapper({
@@ -66,6 +70,8 @@ const ItemContextWrapper = memo<ItemWrapperProps>(function ItemContextWrapper({
   onSetManualPrice,
   lazyRenderHeight,
   lazyRenderOffset,
+  showSku,
+  showBundles,
 }) {
   const context = useMemo(
     () => ({
@@ -78,6 +84,8 @@ const ItemContextWrapper = memo<ItemWrapperProps>(function ItemContextWrapper({
       onRemove: () => onRemove(item.uniqueId, item),
       onSetManualPrice: (price: number, index: number) =>
         onSetManualPrice?.(price, index),
+      showSku,
+      showBundles,
     }),
     [
       item,
@@ -87,6 +95,8 @@ const ItemContextWrapper = memo<ItemWrapperProps>(function ItemContextWrapper({
       onRemove,
       onSetManualPrice,
       shouldAllowManualPrice,
+      showSku,
+      showBundles,
     ]
   )
 
@@ -137,6 +147,8 @@ const ProductList = memo<Props>(function ProductList(props) {
     userType = 'STORE_USER',
     allowManualPrice = false,
     children,
+    showSku,
+    showBundles,
   } = props
 
   const shouldAllowManualPrice =
@@ -181,6 +193,8 @@ const ProductList = memo<Props>(function ProductList(props) {
             {...props}
             lazyRenderHeight={lazyRenderHeight}
             lazyRenderOffset={lazyRenderOffset}
+            showSku={showSku ?? false}
+            showBundles={showBundles ?? false}
           >
             {children}
           </ItemContextWrapper>
@@ -208,6 +222,8 @@ const ProductList = memo<Props>(function ProductList(props) {
             {...props}
             lazyRenderHeight={lazyRenderHeight}
             lazyRenderOffset={lazyRenderOffset}
+            showSku={showSku ?? false}
+            showBundles={showBundles ?? false}
           >
             {children}
           </ItemContextWrapper>

--- a/react/ProductName.tsx
+++ b/react/ProductName.tsx
@@ -9,8 +9,9 @@ import { opaque } from './utils/opaque'
 const CSS_HANDLES = ['productName'] as const
 
 const ProductName: FunctionComponent = () => {
-  const { item, loading } = useItemContext()
+  const { item, loading, showSku } = useItemContext()
   const { rootPath = '' } = useRuntime()
+  const hasSkuName = item.skuName && item.skuName.length > 0
   const handles = useCssHandles(CSS_HANDLES)
 
   if (loading) {
@@ -25,7 +26,7 @@ const ProductName: FunctionComponent = () => {
       } ${opaque(item.availability)}`}
       href={item.detailUrl ? rootPath + item.detailUrl : undefined}
     >
-      {item.name}
+      {showSku && hasSkuName ? item.skuName : item.name}
     </a>
   )
 }

--- a/react/__fixtures__/items.ts
+++ b/react/__fixtures__/items.ts
@@ -24,6 +24,7 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
   {
     index: 1,
@@ -48,6 +49,7 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
   {
     index: 2,
@@ -72,5 +74,6 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
 ]

--- a/react/package.json
+++ b/react/package.json
@@ -24,17 +24,18 @@
     "@vtex/test-tools": "^3.0.0",
     "apollo-client": "^2.5.1",
     "typescript": "3.9.7",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
-    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",
+    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.19.0/public/@types/vtex.flex-layout",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
-    "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
+    "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.5.0/public/@types/vtex.formatted-price",
     "vtex.on-view": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.11.1/public/@types/vtex.order-manager",
+    "vtex.product-list": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list@0.35.0/public/@types/vtex.product-list",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.0/public/@types/vtex.styleguide"
   },
   "version": "0.35.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5976,9 +5976,9 @@ vtex-tachyons@^3.2.0:
   resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-3.2.2.tgz#e9e39d939778ef7d80a92c476cecf7417f79a6e8"
   integrity sha512-4M53uuvV+2XEjplVYiPgpBuaI5dtGksVgz/20NNjbZkXklJM7Lwgod/hOoh3PtIn36+95zZVVgXYfs3e6EU8YA==
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
-  version "0.55.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql":
+  version "0.65.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql#04a998a449f1f5c293b5117d147bcb365d2b321b"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -5988,37 +5988,41 @@ vtex-tachyons@^3.2.0:
   version "0.2.6"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector#3219242fa5c2f14023d33c3549c2d8de93c76d1f"
 
-"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout":
-  version "0.15.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout#1b3e061cec4711dea3a0b98ce3d0434fdcca890b"
+"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.19.0/public/@types/vtex.flex-layout":
+  version "0.19.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.19.0/public/@types/vtex.flex-layout#042e0e1770bafdd157705abefffe0b2645a98f84"
 
 "vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency":
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency#1cb7360452552301237c16d32037bbac61798f20"
 
-"vtex.formatted-price@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price":
-  version "0.4.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price#821e3f087065704d02ee28e4f41aada3d6cb46da"
+"vtex.formatted-price@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.5.0/public/@types/vtex.formatted-price":
+  version "0.5.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.5.0/public/@types/vtex.formatted-price#83cdbfaaa285def9342c6dc1d0d39e858c06afe5"
 
 "vtex.on-view@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view":
   version "1.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view#916225c5bdf7efdcaeef79928a6706b74154813a"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager":
-  version "0.9.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager#95626778e7cff8c8e70f0a3b09348937043f6d21"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.11.1/public/@types/vtex.order-manager":
+  version "0.11.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.11.1/public/@types/vtex.order-manager#cc658148c5e054900c0d692a26d1ac7c872d9262"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
-  version "8.126.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"
+"vtex.product-list@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list@0.35.0/public/@types/vtex.product-list":
+  version "0.35.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-list@0.35.0/public/@types/vtex.product-list#1334bd0c9628e1b9ad3c6097d4df7d1abe00e443"
+
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
+  version "8.132.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.0/public/@types/vtex.styleguide":
+  version "9.146.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.0/public/@types/vtex.styleguide#d8f912c8301ea527aee64e597de46cfc97974a26"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/blocks/common.jsonc
+++ b/store/blocks/common.jsonc
@@ -12,7 +12,9 @@
     }
   },
   "flex-layout.row#product-brand": {
-    "children": ["product-brand"],
+    "children": [
+      "product-brand"
+    ],
     "props": {
       "marginBottom": "2"
     }
@@ -20,10 +22,14 @@
   "flex-layout.row#product-name": {
     // Using app prefix here because it might conflict with
     // vtex.store-components:product-name
-    "children": ["vtex.product-list:product-name"]
+    "children": [
+      "vtex.product-list:product-name"
+    ]
   },
   "flex-layout.row#product-variations": {
-    "children": ["product-variations"],
+    "children": [
+      "product-variations"
+    ],
     "props": {
       "marginTop": "2"
     }


### PR DESCRIPTION
#### What problem is this solving?

Some of our clients requested two features:
First, the option to show the **sku name** of the product in the minicart instead of the product name.
Second, display the **bundle items** if there are any, for each product in the minicart.

#### How to test it?

I have added the props **showSku** and **showBundles** for the blocks **product-list-content-desktop** and **product-list-content-mobile**. Setting **showSku** to true will display the sku name instead of the product name, and setting **showBundles** to true will display the bundle items for each product if any. If these features are not needed, set these props to false or do not set them at all; the **default** value is false.

For example, set these props to true and open the minicart to see the changes. It is needed to test using products with **skuName** different from their product name and/or have **bundleItems** (at least one).
```
"product-list-content-mobile":{
    "children": ["flex-layout.row#list-row.mobile"],
    "props": {
      "showSku": true,
      "showBundles": true
    }
  },
```

#### Screenshots or example usage:

Before setting **showSku** to true:

<img width="206" alt="beforeBundles" src="https://user-images.githubusercontent.com/91942975/157235290-05786431-5103-427b-9e85-5230ef49dff1.png">

After setting **showSku** to true:
The sku name which includes the kilogram value is displayed; the promo product has the same name as sku name.

<img width="206" alt="afterBundles" src="https://user-images.githubusercontent.com/91942975/157235298-acbccc16-8942-4f87-84de-48907f7e3674.png">

Before setting **showBundles** to true:

<img width="213" alt="beforeSku" src="https://user-images.githubusercontent.com/91942975/157234443-9c8b9724-6975-40f9-9ff5-33d8bcef1da4.png">

After setting **showBundles** to true:
The **professional** is the insurance for the product, set as a bundleItem.

<img width="209" alt="afterSku" src="https://user-images.githubusercontent.com/91942975/157234579-76087ae8-1212-49be-96e6-cb4fb08b9497.png">
