### PR TITLE
fix: Prevent user to select higher product quantity than its max availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Prevent users to select a higher product quantity than its maximum availability.
+
 ## [0.36.0] - 2023-01-02
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
     "vtex.format-currency": "0.x",
     "vtex.formatted-price": "0.x",
     "vtex.order-manager": "0.x",
+    "vtex.product-context": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.on-view": "1.x"

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,6 @@
     "vtex.format-currency": "0.x",
     "vtex.formatted-price": "0.x",
     "vtex.order-manager": "0.x",
-    "vtex.product-context": "0.x",
     "vtex.store-icons": "0.x",
     "vtex.styleguide": "9.x",
     "vtex.on-view": "1.x"

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
   },
   "mustUpdateAt": "2019-04-02",
   "dependencies": {
+    "vtex.search-graphql": "0.x",
     "vtex.checkout-graphql": "0.x",
     "vtex.css-handles": "0.x",
     "vtex.device-detector": "0.x",

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import classnames from 'classnames'
 import { Loading } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
+import useProduct from 'vtex.product-context/useProduct'
 
 import Selector from './components/QuantitySelector'
 import QuantityStepper from './components/QuantityStepper'
@@ -32,8 +33,12 @@ const QuantitySelector: VFC<Props> = ({
   mode = 'default',
   quantitySelectorStep = 'unitMultiplier',
 }) => {
+  const { selectedItem } = useProduct()
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
+  const maxValue =
+    selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ??
+    MAX_ITEM_QUANTITY
 
   if (loading) {
     return <Loading />
@@ -59,7 +64,7 @@ const QuantitySelector: VFC<Props> = ({
         <QuantityStepper
           id={item.id}
           value={item.quantity}
-          maxValue={MAX_ITEM_QUANTITY}
+          maxValue={maxValue}
           onChange={onQuantityChange}
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
@@ -85,7 +90,7 @@ const QuantitySelector: VFC<Props> = ({
       <Selector
         id={item.id}
         value={item.quantity}
-        maxValue={MAX_ITEM_QUANTITY}
+        maxValue={maxValue}
         onChange={onQuantityChange}
         disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -59,7 +59,7 @@ const QuantitySelector: VFC<Props> = ({
         <QuantityStepper
           id={item.id}
           value={item.quantity}
-          maxValue={MAX_ITEM_QUANTITY}
+          maxValue={item.availableQuantity ?? MAX_ITEM_QUANTITY}
           onChange={onQuantityChange}
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
@@ -85,7 +85,7 @@ const QuantitySelector: VFC<Props> = ({
       <Selector
         id={item.id}
         value={item.quantity}
-        maxValue={MAX_ITEM_QUANTITY}
+        maxValue={item.availableQuantity ?? MAX_ITEM_QUANTITY}
         onChange={onQuantityChange}
         disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -10,8 +10,8 @@ import { useItemContext } from './ItemContext'
 import { AVAILABLE, CANNOT_BE_DELIVERED } from './constants/Availability'
 import { opaque } from './utils/opaque'
 import styles from './styles.css'
+import useAvailableQuantity from './useAvailableQuantity'
 
-const MAX_ITEM_QUANTITY = 99999
 const CSS_HANDLES = ['quantitySelectorContainer'] as const
 
 type QuantitySelectorMode = 'default' | 'stepper'
@@ -34,6 +34,7 @@ const QuantitySelector: VFC<Props> = ({
 }) => {
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
+  const { availableQuantity } = useAvailableQuantity(item)
 
   if (loading) {
     return <Loading />
@@ -59,7 +60,7 @@ const QuantitySelector: VFC<Props> = ({
         <QuantityStepper
           id={item.id}
           value={item.quantity}
-          maxValue={MAX_ITEM_QUANTITY}
+          maxValue={availableQuantity}
           onChange={onQuantityChange}
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
@@ -85,7 +86,7 @@ const QuantitySelector: VFC<Props> = ({
       <Selector
         id={item.id}
         value={item.quantity}
-        maxValue={MAX_ITEM_QUANTITY}
+        maxValue={availableQuantity}
         onChange={onQuantityChange}
         disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -59,7 +59,7 @@ const QuantitySelector: VFC<Props> = ({
         <QuantityStepper
           id={item.id}
           value={item.quantity}
-          maxValue={item.availableQuantity ?? MAX_ITEM_QUANTITY}
+          maxValue={MAX_ITEM_QUANTITY}
           onChange={onQuantityChange}
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
@@ -85,7 +85,7 @@ const QuantitySelector: VFC<Props> = ({
       <Selector
         id={item.id}
         value={item.quantity}
-        maxValue={item.availableQuantity ?? MAX_ITEM_QUANTITY}
+        maxValue={MAX_ITEM_QUANTITY}
         onChange={onQuantityChange}
         disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}

--- a/react/QuantitySelector.tsx
+++ b/react/QuantitySelector.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import classnames from 'classnames'
 import { Loading } from 'vtex.render-runtime'
 import { useCssHandles, applyModifiers } from 'vtex.css-handles'
-import useProduct from 'vtex.product-context/useProduct'
 
 import Selector from './components/QuantitySelector'
 import QuantityStepper from './components/QuantityStepper'
@@ -33,12 +32,8 @@ const QuantitySelector: VFC<Props> = ({
   mode = 'default',
   quantitySelectorStep = 'unitMultiplier',
 }) => {
-  const { selectedItem } = useProduct()
   const { item, loading, onQuantityChange } = useItemContext()
   const handles = useCssHandles(CSS_HANDLES)
-  const maxValue =
-    selectedItem?.sellers?.[0]?.commertialOffer?.AvailableQuantity ??
-    MAX_ITEM_QUANTITY
 
   if (loading) {
     return <Loading />
@@ -64,7 +59,7 @@ const QuantitySelector: VFC<Props> = ({
         <QuantityStepper
           id={item.id}
           value={item.quantity}
-          maxValue={maxValue}
+          maxValue={MAX_ITEM_QUANTITY}
           onChange={onQuantityChange}
           unitMultiplier={unitMultiplier}
           disabled={shouldDisableSelector(item.availability)}
@@ -90,7 +85,7 @@ const QuantitySelector: VFC<Props> = ({
       <Selector
         id={item.id}
         value={item.quantity}
-        maxValue={maxValue}
+        maxValue={MAX_ITEM_QUANTITY}
         onChange={onQuantityChange}
         disabled={shouldDisableSelector(item.availability)}
         unitMultiplier={unitMultiplier}

--- a/react/__fixtures__/items.ts
+++ b/react/__fixtures__/items.ts
@@ -24,7 +24,6 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
-    isGift: false,
   },
   {
     index: 1,
@@ -49,7 +48,6 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
-    isGift: false,
   },
   {
     index: 2,
@@ -74,6 +72,5 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
-    isGift: false,
   },
 ]

--- a/react/__fixtures__/items.ts
+++ b/react/__fixtures__/items.ts
@@ -24,6 +24,7 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
   {
     index: 1,
@@ -48,6 +49,7 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
   {
     index: 2,
@@ -72,5 +74,6 @@ export const items: Array<Item & { index: number }> = [
     bundleItems: [],
     offerings: [],
     attachments: [],
+    isGift: false,
   },
 ]

--- a/react/graphql/queries/GetAvailableQuantity.graphql
+++ b/react/graphql/queries/GetAvailableQuantity.graphql
@@ -1,0 +1,13 @@
+query GetProduct($id: ID!) {
+  product(identifier: { field: sku, value: $id })
+    @context(provider: "vtex.search-graphql") {
+    items {
+      itemId
+      sellers {
+        commertialOffer {
+          AvailableQuantity
+        }
+      }
+    }
+  }
+}

--- a/react/package.json
+++ b/react/package.json
@@ -32,7 +32,6 @@
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.on-view": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
-    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"

--- a/react/package.json
+++ b/react/package.json
@@ -33,6 +33,7 @@
     "vtex.on-view": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
+    "vtex.search-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.50.0/public/@types/vtex.search-graphql",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
   },

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "@vtex/test-tools": "^3.0.0",
     "apollo-client": "^2.5.1",
     "typescript": "3.9.7",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",

--- a/react/package.json
+++ b/react/package.json
@@ -32,6 +32,7 @@
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.on-view": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.on-view@1.0.0/public/@types/vtex.on-view",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
+    "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
     "vtex.store-icons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"

--- a/react/package.json
+++ b/react/package.json
@@ -24,7 +24,7 @@
     "@vtex/test-tools": "^3.0.0",
     "apollo-client": "^2.5.1",
     "typescript": "3.9.7",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.device-detector": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.device-detector@0.2.6/public/@types/vtex.device-detector",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",

--- a/react/package.json
+++ b/react/package.json
@@ -5,9 +5,10 @@
   },
   "dependencies": {
     "@vtex/css-handles": "^1.0.0",
+    "apollo-client": "^2.6.8",
     "classnames": "^2.2.6",
     "react": "^16.8.3",
-    "react-apollo": "^2.5.8",
+    "react-apollo": "^3.1.3",
     "react-dom": "^16.8.3",
     "react-intl": "3",
     "react-sizeme": "^2.6.7"

--- a/react/useAvailableQuantity.tsx
+++ b/react/useAvailableQuantity.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from 'react-apollo'
+import type { Product } from 'vtex.search-graphql'
+import type { Item } from 'vtex.checkout-graphql'
+
+import GetAvailableQuantity from './graphql/queries/GetAvailableQuantity.graphql'
+
+const MAX_ITEM_QUANTITY = 99999
+
+export default function useAvailableQuantity(item: Item) {
+  const [availableQuantity, setAvailableQuantity] = useState(MAX_ITEM_QUANTITY)
+  const [skip, setSkip] = useState(false)
+  const { data, loading } = useQuery<{ product: Product }>(
+    GetAvailableQuantity,
+    {
+      variables: { id: Number(item.id) },
+      skip,
+    }
+  )
+
+  useEffect(() => {
+    if (!data) return
+
+    setSkip(true)
+
+    const sku = data.product.items?.find(
+      (productItem) => item.id === productItem?.itemId
+    )
+
+    const maxQuantity = sku?.sellers?.[0]?.commertialOffer?.AvailableQuantity
+
+    setAvailableQuantity(maxQuantity ?? MAX_ITEM_QUANTITY)
+  }, [data, loading, item.id])
+
+  return { availableQuantity }
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6008,6 +6008,10 @@ vtex-tachyons@^3.2.0:
   version "0.9.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager#95626778e7cff8c8e70f0a3b09348937043f6d21"
 
+"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
+
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
   version "8.126.7"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6008,10 +6008,6 @@ vtex-tachyons@^3.2.0:
   version "0.9.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager#95626778e7cff8c8e70f0a3b09348937043f6d21"
 
-"vtex.product-context@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context":
-  version "0.10.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
-
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
   version "8.126.7"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6012,6 +6012,10 @@ vtex-tachyons@^3.2.0:
   version "8.126.7"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"
 
+"vtex.search-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.50.0/public/@types/vtex.search-graphql":
+  version "0.50.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.search-graphql@0.50.0/public/@types/vtex.search-graphql#e29e418461f338165a1f4ddaf2ed0fd2e7246420"
+
 "vtex.store-icons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons":
   version "0.18.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-icons@0.18.0/public/@types/vtex.store-icons#0ee94d549aa283ce3a13ab987c13eac4fdfd1bba"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1784,7 +1784,7 @@ apollo-cache@1.3.5, apollo-cache@^1.3.5:
     apollo-utilities "^1.3.4"
     tslib "^1.10.0"
 
-apollo-client@^2.5.1, apollo-client@^2.6.4:
+apollo-client@^2.6.4, apollo-client@^2.6.8:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.10.tgz#86637047b51d940c8eaa771a4ce1b02df16bea6a"
   integrity sha512-jiPlMTN6/5CjZpJOkGeUV0mb4zxx33uXWdj/xQCfAMkuNAC3HN7CvYDyMHHEzmcQ5GV12LszWoQ/VlxET24CtA==
@@ -4165,11 +4165,6 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -4798,19 +4793,6 @@ raf@^3.4.0:
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
   dependencies:
     performance-now "^2.1.0"
-
-react-apollo@^2.5.8:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
-  integrity sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==
-  dependencies:
-    apollo-utilities "^1.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    hoist-non-react-statics "^3.3.0"
-    lodash.isequal "^4.5.0"
-    prop-types "^15.7.2"
-    ts-invariant "^0.4.2"
-    tslib "^1.9.3"
 
 react-apollo@^3.1.3:
   version "3.1.5"
@@ -5806,7 +5788,7 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.2, ts-invariant@^0.4.4:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5976,9 +5976,9 @@ vtex-tachyons@^3.2.0:
   resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-3.2.2.tgz#e9e39d939778ef7d80a92c476cecf7417f79a6e8"
   integrity sha512-4M53uuvV+2XEjplVYiPgpBuaI5dtGksVgz/20NNjbZkXklJM7Lwgod/hOoh3PtIn36+95zZVVgXYfs3e6EU8YA==
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
-  version "0.55.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql":
+  version "0.67.0-beta.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql#4edd95dd0841f22a1f8efca15eff205d9d26754f"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5976,9 +5976,9 @@ vtex-tachyons@^3.2.0:
   resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-3.2.2.tgz#e9e39d939778ef7d80a92c476cecf7417f79a6e8"
   integrity sha512-4M53uuvV+2XEjplVYiPgpBuaI5dtGksVgz/20NNjbZkXklJM7Lwgod/hOoh3PtIn36+95zZVVgXYfs3e6EU8YA==
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql":
-  version "0.67.0-beta.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.67.0-beta.0/public/@types/vtex.checkout-graphql#4edd95dd0841f22a1f8efca15eff205d9d26754f"
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql":
+  version "0.55.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.55.1/public/@types/vtex.checkout-graphql#a9f282941d74fffac3d3d877d92313dd755de07f"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"


### PR DESCRIPTION
#### What problem is this solving?

Fix the [Known Issue - Quantity selector component doesn't return to the limit value when user quickly clicks](https://vtexhelp.zendesk.com/agent/tickets/659909). The `QuantityStepper` and `QuantitySelector` components already have a [`maxValue`](https://github.com/vtex-apps/product-list/blob/8bb6492114ed0b78ea17da36d86c51e84600cb04/react/QuantitySelector.tsx#L62-L88) prop that prevents the user from going above the limit. However, we were using a hardcoded value of 99999 as part of the variable [`MAX_ITEM_QUANTITY`](https://github.com/vtex-apps/product-list/blob/8bb6492114ed0b78ea17da36d86c51e84600cb04/react/QuantitySelector.tsx#L14). The `item` object used did not have a property that holds the maximum available quantity we could use. We were able to include it by updating the [checkout-graphql](https://github.com/vtex-apps/checkout-graphql/pull/187) and [checkout-resources](https://github.com/vtex-apps/checkout-resources/pull/99) apps.

#### Expected order of events

1. https://github.com/vtex-apps/checkout-graphql/pull/187 is deployed.
2. https://github.com/vtex-apps/checkout-resources/pull/99 is deployed.
3. This PR can be deployed.

#### How to test it?

Before|After
-|-
![Before](https://user-images.githubusercontent.com/381395/213585868-52ed72a6-9ea1-4838-a1c5-18531fa6b108.gif)|![After](https://user-images.githubusercontent.com/381395/213585877-aa1ff4eb-002e-458c-800e-6e9f5b611eab.gif)

On this PDP, the max availability for the product is 3. Add the product to the cart, and, in the mini cart, you shouldn't be able to increase its quantity past 3, even if you click quickly.

[Workspace](https://ki564283filipelima--lojadokadu.myvtex.com/livro/p)

#### Notes

- https://github.com/vtex-apps/checkout-graphql/pull/187 where the field has been added.
- https://github.com/vtex-apps/checkout-resources/pull/99 where the field is going to be queried.