### PR TITLE
docs: splitItem prop in minicart-product-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated README.md file
 
 ## [0.37.2] - 2023-05-12
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -269,7 +269,7 @@ In order to customize the `product-list` configuration, copy the code above, pas
 
 | Prop name | Type   | Description                                                                                                                                                                         | Default value |
 | --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `splitItem`  | `boolean` | Determine whether products with attachments should be split and treated as individual items (`true`) or not (`false`) when increasing the quantity in the minicart | `false`        |
+| `splitItem`  | `boolean` | Determines whether products with attachments should be split and treated as individual items (`true`) or as a single item (`false`) when their quantity is increased in the minicart. | `false`        |
 
 
 ### `product-list` props

--- a/docs/README.md
+++ b/docs/README.md
@@ -265,6 +265,13 @@ In order to customize the `product-list` configuration, copy the code above, pas
 | `quantity-selector`            | Renders a selector that allows users to choose how many units of a product they want to add to the cart.                                                                                                                                                                                               |
 | `remove-button`                | Renders a button that allows users to remove a product from the list.                                                                                                                                                                                                                                  |
 
+### `minicart-product-list` props
+
+| Prop name | Type   | Description                                                                                                                                                                         | Default value |
+| --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `splitItem`  | `boolean` | Check if products with attachments will be splitted and considered as individual `true` or not `false` when increasing the quantity in minicart | `false`        |
+
+
 ### `product-list` props
 
 | Prop name          | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Default value |

--- a/docs/README.md
+++ b/docs/README.md
@@ -269,7 +269,7 @@ In order to customize the `product-list` configuration, copy the code above, pas
 
 | Prop name | Type   | Description                                                                                                                                                                         | Default value |
 | --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `splitItem`  | `boolean` | Check if products with attachments will be splitted and considered as individual `true` or not `false` when increasing the quantity in minicart | `false`        |
+| `splitItem`  | `boolean` | Determine whether products with attachments should be split and treated as individual items (`true`) or not (`false`) when increasing the quantity in the minicart | `false`        |
 
 
 ### `product-list` props


### PR DESCRIPTION
#### What problem is this solving?

This PR aims to fix (add a new param) to the KI: #337069, adding a new prop called splitItem in minicart-product-list.

Even though the implementation of this component is in Minicart app, all references from product-list using Minicart and advanced usage to implement are here and not in Minicart

For further context:

https://github.com/vtex-apps/minicart/pull/334

#### Screenshots or example usage:

<img width="858" alt="image" src="https://github.com/vtex-apps/product-list/assets/13649073/ffb6f51e-e5c5-49d5-b491-5d025109600f">


#### Describe alternatives you've considered, if any.

Move the documentation regarding minicart-product-list to minicart app itself

#### Related to / Depends on

https://github.com/vtex-apps/checkout-resources/pull/102
https://github.com/vtex-apps/minicart/pull/334
https://github.com/vtex/order-items/pull/38


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXdjbTNzb2poNmxwYjc0djltaHMwcW02ZnpzdDk5cmY1b3h2ZjNpYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/yB22VAMAY8XNS/giphy.gif)
