### PR TITLE
Add null if item.listPrice condition is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added null to condition in Price.tsx so that if product list price is 0, react will render null instead of a duplicative 0 along with 'free'.
+
 ### Changed
 
 - Update GitHub actions/cache to v4

--- a/react/Price.tsx
+++ b/react/Price.tsx
@@ -37,7 +37,7 @@ const Price: React.FC<PriceProps> = ({
         handles.productPriceContainer
       } ${parseTextAlign(textAlign)}`}
     >
-      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice && (
+      {item.listPrice && item.listPrice !== item.sellingPrice && showListPrice ? (
         <div
           id={`list-price-${item.id}`}
           className={`${handles.productPriceCurrency}  ${applyModifiers(
@@ -52,7 +52,7 @@ const Price: React.FC<PriceProps> = ({
             }
           />
         </div>
-      )}
+      ) : null}
       <div
         id={`price-${item.id}`}
         className={`${handles.productPrice} ${applyModifiers(


### PR DESCRIPTION
#### What problem is this solving?

Fixing a bug where if product list price is 0, the condition returns a 0, meaning react renders a 0 along with the 'free' in the mini cart. Adding the null means react will explicitly render null if the condition is false, even if the product list price is 0.

#### How to test it?

1. Log in
2. Add a free product to cart
3. Click cart to view product in mini cart

[Workspace](https://ailbhe2--colproeudev.myvtex.com/)

#### Screenshots or example usage:

Before:
![Screenshot 2025-07-08 at 11 32 50](https://github.com/user-attachments/assets/d198accd-23db-4612-9199-805887ccedee)

After:
![Screenshot 2025-07-08 at 11 30 21](https://github.com/user-attachments/assets/2309fcd9-3c2b-43e5-9cd4-51b8133dee3f)
