### PR TITLE
add: The context of the product list is exported to be able to extend…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Update GitHub actions/cache to v4
 
+## [0.37.4] - 2025-01-02
+### Added
+- Export ItemContextProvider and ItemContext in react/ItemContext file
+
 ## [0.37.3] - 2024-09-05
 ### Fixed
 - Updated README.md file

--- a/react/ItemContext.tsx
+++ b/react/ItemContext.tsx
@@ -16,7 +16,7 @@ interface ItemContextProviderProps {
   value: Context
 }
 
-const ItemContext = createContext<Context | undefined>(undefined)
+export const ItemContext = createContext<Context | undefined>(undefined)
 
 export const ItemContextProvider: FC<ItemContextProviderProps> = ({
   value,
@@ -33,4 +33,4 @@ export const useItemContext = () => {
   return context
 }
 
-export default { useItemContext }
+export default { useItemContext, ItemContextProvider, ItemContext }


### PR DESCRIPTION
#### What problem does this solve?

Properly export the `ItemContext` context, allowing other apps to use it without problems and customizations without modifying the original repository.

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a workspace where this branch is linked -->

https://productlist--experimentality.myvtex.com/?__bindingAddress=experimentality.myvtex.com/

There are no functional changes, only the export of the `ItemContext` context so that it can be used by other apps.

[Workspace](https://productlist--experimentality.myvtex.com/?__bindingAddress=experimentality.myvtex.com/)

#### Screenshots or usage example:

```jsx

import React from 'react'
import { ItemContext } from 'vtex.product-list'
const { useItemContext } = ItemContext

export const Item = () => {
  const { item } = useItemContext()
  return (
    <div className='w-100 flex'>
      <img src={item.imageUrl} alt={item.name} className='w-20 h-20 mr3' />
      <div className='flex flex-column justify-center'>
        <h2 className='f4'>{item.name}</h2>
        <pre className="w-100 ma0 code f6 lh-copy overflow-auto break-word">
          {JSON.stringify({ id: item.id, name: item.name, quantity: item.quantity })}
        </pre>
      </div>
      <div className='flex items-center ml-auto'>
        <span className='mr2'>{item.priceDefinition?.calculatedSellingPrice ?? item.sellingPrice}</span>
      </div>
    </div>
  )
}

export default Item
```

```jsx

import React from 'react'
import { ItemContext } from 'vtex.product-list'

export const Layout = ({ children }) => {
  const item = {} as any // Item from order or other source

  return (
    <ItemContext.ItemContextProvider value={item}>
      {children}
    </ItemContext.ItemContextProvider>
  )
}

export default Layout
```

<!--- Add images or GIFs to show the behavior or layout changes. Example: before and after images -->

#### Describe any alternatives you've considered.

There are no alternatives for this customization of the product list layout, as it requires the ability to export the `ItemContext` context so that it can be used by other applications. The current alternative is a fork of this project to make the customization possible, but it's not ideal since updates cannot be received from the original repository.